### PR TITLE
add team roles files

### DIFF
--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -49,7 +49,7 @@ Non-code contributions can be documented by making a PR to add yourself to CONTR
 Becoming a Community Contributor is the first step towards becoming an Organization Member.
 
 ### Organization Member
-Description: An Organization Member is an established contributor who regularly participates in the project. Organization Members have privileges in project repositories and as such are expected to act in the interests of the whole project. Organization Members can take on additional roles within the project and can work more independently, for example triggering CI. 
+Description: An Organization Member is an established contributor who regularly participates in the project. Organization Members have privileges in project repositories and as such are expected to act in the interests of the whole project. Organization Members can take on [additional roles within the project](CONTRIBUTOR-ROLES.md) and can work more independently, for example triggering CI. 
 
 An Organization Member has all the rights and responsibilities of a Community Contributor, plus:
 
@@ -69,7 +69,7 @@ An Organization Member has all the rights and responsibilities of a Community Co
     * Can trigger CI
     * Can leave reviews on PRs
     * Can recommend other contributors to become Cilium Github Org Members
-    * Can nominate themselves to other roles within Cilium
+    * Can nominate themselves to [other roles within Cilium](CONTRIBUTOR-ROLES.md)
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -131,4 +131,4 @@ Committers have all the rights and responsibilities of a Reviewer, plus:
     * Can nominate new Committers
     * Is listed as a Committer in the MAINTAINERS.md
 
-Committers who are contributing and maintaining project code are automatically part of the Code Team defined in CONTRIBUTOR-ROLES.md.
+Committers who are contributing and maintaining project code are automatically part of the Code Team defined in [CONTRIBUTOR-ROLES.md](CONTRIBUTOR-ROLES.md).

--- a/CONTRIBUTOR-ROLES.md
+++ b/CONTRIBUTOR-ROLES.md
@@ -14,11 +14,11 @@ Triagers are members that help triage issues. They can set assignments and label
 
 The process of becoming a Triage Team member is:
 
-1. Make a PR against the triage team file
+1. Make a PR against the [triage team file](roles/Triage-Team.md)
 2. At least two members who are already Committers, approve the PR
 
 ### Security Team
-Security Team members are listed in the security team file. The security team is responsible for responding to all security issues reported to security@cilium.io or any other community forum. They ensure that the issues are mitigated and a responsible disclosure process is followed in a reasonable time.
+Security Team members are listed in the [security team file](roles/Security-Team.md). The security team is responsible for responding to all security issues reported to security@cilium.io or any other community forum. They ensure that the issues are mitigated and a responsible disclosure process is followed in a reasonable time.
 
 * Responsibilities:
     * Thoroughly investigate all reports to the Security Team
@@ -41,7 +41,7 @@ The process of becoming a security team member is:
 2. Shadowing an existing security team member
 
 ### Community Team
-Community Team members are listed in the community team file. The community team is responsible for helping grow the community around Cilium including managing the public presence of the project, helping the project be present at events and meetups, and applying to relevant programs on the project’s behalf.
+Community Team members are listed in the [community team file](roles/Community-Team.md). The community team is responsible for helping grow the community around Cilium including managing the public presence of the project, helping the project be present at events and meetups, and applying to relevant programs on the project’s behalf.
 
 * Responsibilities:
     * Keeping the Cilium website and social media accounts up to date
@@ -60,7 +60,7 @@ Community Team members are listed in the community team file. The community team
 
 The process of becoming a Community Team member is:
 
-1. Make a PR against the community team file
+1. Make a PR against the [community team file](roles/Community-Team.md)
 2. Approval by one committer
 
 ### CI Team
@@ -80,7 +80,7 @@ The CI team works to keep the CI infrastructure up and running.
 
 The process of becoming a CI Team member is:
 
-1. Make a PR against the CI Team file
+1. Make a PR against the [CI Team file](roles/CI-Team.md)
 2. Approval by one committer
 
 ### Code Team
@@ -99,8 +99,8 @@ The Code Team is the committers responsible for all aspects of the Cilium organi
 * Qualifications:
     * Cilium Committer
 
-### Maintainer
-Maintainers are very established contributors who are responsible for the entire project. They have the same rights as Committers, but have additional administrative and janitorial responsibilities.
+### Maintainers
+[Maintainers](roles/Maintainers.md) are very established contributors who are responsible for the entire project. They have the same rights as Committers, but have additional administrative and janitorial responsibilities.
 
 A Maintainer must meet the responsibilities and qualifications of a Committer, plus:
 

--- a/roles/CI-Team.md
+++ b/roles/CI-Team.md
@@ -1,0 +1,3 @@
+# CI Team
+
+The CI team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#ci-team). The following are the current CI team members:

--- a/roles/Community-Team.md
+++ b/roles/Community-Team.md
@@ -1,0 +1,3 @@
+# Community Team
+
+The community team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#community-team). The following are the current community team members:

--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -1,0 +1,3 @@
+# Maintainers
+
+The Maintainers roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#maintainers). The following are the current maintainers:

--- a/roles/Security-Team.md
+++ b/roles/Security-Team.md
@@ -1,0 +1,3 @@
+# Security Team
+
+The security team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#security-team). The following are the current security team members:

--- a/roles/Triage-Team.md
+++ b/roles/Triage-Team.md
@@ -1,0 +1,3 @@
+# Triage Team
+
+The triage team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#triage-team). The following are the current triage team members:


### PR DESCRIPTION
This PR adds the contributor roles files and links them to the main doc. It covers everything in #4 except the member management file