### PR TITLE
Request org membership for aojea

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -2,6 +2,7 @@ team:
 - aanm
 - aditighag
 - alan-kut
+- aojea
 - asauber
 - aspsk
 - b3a-dev


### PR DESCRIPTION
Per the contributor ladder document https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member I'd like to request membership in the org for myself, since I plan to contribute regularly, mainly in the areas related to Kubernetes where I'm sig-network and sig-testing member and Kind maintainer.

I've already contributed adding more test coverage for the Kubernetes integration to the project
- https://github.com/cilium/cilium/pull/25258
- https://github.com/cilium/cilium/pull/24209 

and fixing some bugs:

- https://github.com/cilium/cilium/pull/24202
- https://github.com/cilium/cilium/pull/24174 and helping to triage issues