### PR TITLE
Add docs-structure team members

### DIFF
--- a/ladder/teams/docs-structure.yaml
+++ b/ladder/teams/docs-structure.yaml
@@ -1,0 +1,4 @@
+members:
+- joestringer
+- qmonnet
+- zacharysarah


### PR DESCRIPTION
Add docs-structure team and existing members to the repository. Some contributors have volunteered to join the team, this PR should make it easier for them to apply.
