### PR TITLE
Add AwesomePatrol to organization members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -5,6 +5,7 @@ team:
 - aojea
 - asauber
 - aspsk
+- AwesomePatrol
 - b3a-dev
 - bimmlerd
 - bmcustodio


### PR DESCRIPTION
I request to join as an organization member to Cilium project in accordance with https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member

My contributions:
 * Hubble field mask:
   * https://github.com/cilium/cilium/pull/23198
   * https://github.com/cilium/hubble/pull/1101
 * misc:
   * https://github.com/cilium/hubble-otel/pull/97
   * https://github.com/cilium/hubble-otel/pull/96
   * https://github.com/cilium/cilium/pull/21860
 * in-progress:
   * https://github.com/cilium/cilium/issues/25508
     * https://github.com/cilium/cilium/pull/26379
   * https://github.com/cilium/cilium/pull/26367

I plan to continue contributing and be further involved in the project, especially Hubble.