### PR TITLE
Remove Varun Marupadi from Cilium Security

### DIFF
--- a/roles/Security-Team.md
+++ b/roles/Security-Team.md
@@ -12,6 +12,5 @@ The security team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md
 * [Natália Réka Ivánkó](https://github.com/sharlns)
 * [Maciej Kwiek](https://github.com/nebril)
 * [Thomas Graf](https://github.com/tgraf)
-* [Varun Marupadi](https://github.com/varunmar)
 * [Liz Rice](https://github.com/lizrice)
 * [Tam Mach](https://github.com/sayboras)


### PR DESCRIPTION
Varun has opted to step down from the team.