### PR TITLE
sig-policy: Add myself to policy team

### DIFF
--- a/ladder/teams/sig-policy.yaml
+++ b/ladder/teams/sig-policy.yaml
@@ -7,3 +7,4 @@ members:
 - jrajahalme
 - nathanjsweet
 - nebril
+- sayboras


### PR DESCRIPTION
I am slowly learning Cilium policy, so would like to join sig-policy team and help whenever I can.