### PR TITLE
SIG-BGP Team: Adds danehans

### DIFF
--- a/ladder/teams/sig-bgp.yaml
+++ b/ladder/teams/sig-bgp.yaml
@@ -3,3 +3,4 @@ members:
 - harsimran-pabla
 - ldelossa
 - rastislavs
+- danehans


### PR DESCRIPTION
I have been an [active contributor](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Adanehans+) and [org member](https://github.com/cilium/community/blob/main/ladder/members.yaml) for the past 5 months with a focus on BGP Control Plane. I intend on continuing in this role and would like to be part of the `SIG-BGP` team.