### PR TITLE
SIG-AGENT: Adds danehans

### DIFF
--- a/ladder/teams/sig-agent.yaml
+++ b/ladder/teams/sig-agent.yaml
@@ -27,3 +27,4 @@ members:
 - tommyp1ckles
 - vadorovsky
 - youngnick
+- danehans


### PR DESCRIPTION
I have been an [active contributor](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Adanehans+) and [org member](https://github.com/cilium/community/blob/main/ladder/members.yaml) for the past 5 months. Although I have mainly focused on the BGP Control Plane, I have contributed to other areas that fall under Cilium Agent, e.g. L2 announcer, node pkg, etc. I intend on continuing in this role and would like to be part of the `SIG-AGENT` team.