### PR TITLE
SIG-K8S: Adds danehans

### DIFF
--- a/ladder/teams/sig-k8s.yaml
+++ b/ladder/teams/sig-k8s.yaml
@@ -11,3 +11,4 @@ members:
 - tgraf
 - tommyp1ckles
 - youngnick
+- danehans


### PR DESCRIPTION
I have been an [active contributor](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Adanehans+) and [org member](https://github.com/cilium/community/blob/main/ladder/members.yaml) for the past 5 months. Although I have mainly focused on the BGP Control Plane, I have contributed to other areas that fall under SIG-K8S. I intend on continuing in this role and would like to be part of the `SIG-K8S` team.