### PR TITLE
Remove lmb from sig-agent and sig-datapath

### DIFF
--- a/ladder/teams/sig-agent.yaml
+++ b/ladder/teams/sig-agent.yaml
@@ -12,7 +12,6 @@ members:
 - joamaki
 - joestringer
 - ldelossa
-- lmb
 - marseel
 - meyskens
 - mhofstetter

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -18,7 +18,6 @@ members:
 - julianwiedmann
 - kkourt
 - ldelossa
-- lmb
 - markpash
 - nathanjsweet
 - nirmoy


### PR DESCRIPTION
Remove myself from these two very broad teams since it makes code review more complicated.