### PR TITLE
docs: add general guidance on contributor expectations

### DIFF
--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -152,7 +152,9 @@ Inactive members are defined as members of the Cilium org with **no** contributi
 
 ## General guidance on making contributions and expectations
 
-We welcome people to raise PRs, issues and CFPs but please bear in mind that it takes time and effort to review them properly, and as an open source project we don’t make any guarantees about how quickly they will get looked at. Committers and reviewers may have other pressures on their time that mean they don’t currently have the bandwidth to look at your proposal. 
+We welcome people to raise PRs, issues and CFPs in the Cilium project. If you're new to the project we'd strongly encourage you to start off with small, but meaningful, changes first, as these are easier and quicker for committers / reviewers to assess and give feedback on. You'll get the opportunity to learn about the [process and expectations](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/) of making changes within the project. 
+
+As an open source project we don’t make any guarantees about how quickly proposed changes will get looked at. Committers and reviewers may have other pressures on their time, that mean they don’t currently have the bandwidth to look at your proposal. 
 
 Naturally, the more an individual has already contributed to the project, the higher the level of trust and confidence that the person will have established in the community. Starting with smaller proposals, fixes and maintenance work can help build up that trust and confidence. 
 

--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -156,7 +156,7 @@ We welcome people to raise PRs, issues and CFPs in the Cilium project. If you're
 
 As an open source project we don’t make any guarantees about how quickly proposed changes will get looked at. Committers and reviewers may have other pressures on their time, that mean they don’t currently have the bandwidth to look at your proposal. 
 
-Naturally, the more an individual has already contributed to the project, the higher the level of trust and confidence that the person will have established in the community. Starting with smaller proposals, fixes and maintenance work can help build up that trust and confidence. 
+Naturally, the more an individual has already contributed to the project, the higher the level of trust and confidence that the person will have established in the community. Starting with smaller proposals, fixes and maintenance work, or making constructive and meaningful review comments on other people's suggestions, can help build up that trust and confidence. 
 
 Accepting any change into the project means that the committers are signing up to maintain it going forward. To quote [Solomon Hykes](https://x.com/solomonstre/status/715277134978113536?s=20), "no is temporary, yes is forever". For major changes, just being willing to push through the development work may not be enough - it’s likely you will need a track record of contributions to convince the community that you’ll be around to maintain changes into the future. 
 

--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -150,3 +150,11 @@ Inactive members are defined as members of the Cilium org with **no** contributi
 
 **Note:** Devstats does not take into account non-code contributions. If a non-code contributing member is accidentally removed this way, they may open an issue to quickly be re-instated.
 
+## General guidance on making contributions and expectations
+
+We welcome people to raise PRs, issues and CFPs but please bear in mind that it takes time and effort to review them properly, and as an open source project we don’t make any guarantees about how quickly they will get looked at. Committers and reviewers may have other pressures on their time that mean they don’t currently have the bandwidth to look at your proposal. 
+
+Naturally, the more an individual has already contributed to the project, the higher the level of trust and confidence that the person will have established in the community. Starting with smaller proposals, fixes and maintenance work can help build up that trust and confidence. 
+
+Accepting any change into the project means that the committers are signing up to maintain it going forward. To quote [Solomon Hykes](https://x.com/solomonstre/status/715277134978113536?s=20), "no is temporary, yes is forever". For major changes, just being willing to push through the development work may not be enough - it’s likely you will need a track record of contributions to convince the community that you’ll be around to maintain changes into the future. 
+


### PR DESCRIPTION
This follows a discussion in the Committers channel about how (would-be) contributors sometimes have unreasonable expectations on how quickly (and how) the project should respond to their ideas