### PR TITLE
#89 - Document tool admins

### DIFF
--- a/ADMINS-FOR-CILIUM.md
+++ b/ADMINS-FOR-CILIUM.md
@@ -1,0 +1,22 @@
+# Admins for Cilium
+
+This document lists the individuals responsible for the various bits of infrastructure that support the Cilium project. Ping these folks if you experience issues or need special access.
+
+| Service | Purpose | Admins |
+|---------|---------|--------|
+| [Algolia](https://www.algolia.com/) | Search engine for cilium.io | [aanm](https://github.com/aanm), [joestringer](https://github.com/joestringer)
+| [Artifact Hub](https://artifacthub.io/) | Kubernetes packages | [aanm](https://github.com/aanm), [joestringer](https://github.com/joestringer)
+| [Docker Hub](https://hub.docker.com/u/cilium) | Container registry | [aanm](https://github.com/aanm), [joestringer](https://github.com/joestringer)
+| [ebpf-go.dev](https://ebpf-go.dev/) | eBPF library for Go | [lmb](https://github.com/lmb)
+| [Formspree](https://formspree.io/) | Website forms for cilium.io | [xmulligan](https://github.com/xmulligan)
+| [GitHub](https://github.com/cilium) | Source control, bug tracking | [aanm](https://github.com/aanm), [joestringer](https://github.com/joestringer)
+| [Cloud DNS](https://cloud.google.com/dns) | DNS hosting for cilium.io | [xmulligan](https://github.com/xmulligan)
+| [Google Workspace](https://workspace.google.com/) | Cilium workspace | [tgraf](https://github.com/tgraf)
+| [LinkedIn](https://www.linkedin.com/company/cilium/) | Cilium LinkedIn account | [Cilium community team](https://github.com/cilium/community/blob/main/CONTRIBUTOR-ROLES.md#community-team)
+| [Netlify](https://www.netlify.com/) | Website hosting for cilium.io | [xmulligan](https://github.com/xmulligan)
+| [Quay.io](https://quay.io/) | Container registry | [aanm](https://github.com/aanm), [joestringer](https://github.com/joestringer)
+| [Read the Docs](https://docs.cilium.io/en/stable/) | Cilium documentation | [aanm](https://github.com/aanm), [borkmann](https://github.com/borkmann), [joestringer](https://github.com/joestringer), [tgraf](https://github.com/tgraf)
+| [Slack](https://cilium.herokuapp.com/) | Cilium & eBPF chat plaform | [Cilium community team](https://github.com/cilium/community/blob/main/CONTRIBUTOR-ROLES.md#community-team)
+| [tetragon.io](https://tetragon.io/) | Website for Tetragon | [mtardy](https://github.com/mtardy)
+| [Twitter](https://twitter.com/ciliumproject) | Cilium Twitter account | [Cilium community team](https://github.com/cilium/community/blob/main/CONTRIBUTOR-ROLES.md#community-team)
+| [Zoom](https://zoom.us/) | Project meetings | [xmulligan](https://github.com/xmulligan)


### PR DESCRIPTION
This is what I have found so far for tools based on [Istio's tools](https://github.com/istio/community/blob/master/ADMINS-FOR-ISTIO.md). All of the 'Google' tools I am assuming we have, but we may not use all of them. I have put @xmulligan as the owner for all the website tools as he seems to be the most active in that repo, but I am not sure if he actually is the right point of contact.