### PR TITLE
ladder: Add gandro to aws, sig-k8s and sig-policy

### DIFF
--- a/ladder/teams/aws.yaml
+++ b/ladder/teams/aws.yaml
@@ -1,6 +1,7 @@
 members:
 - christarazi
 - doniacld
+- gandro
 - hemanthmalla
 - tgraf
 - ungureanuvladvictor

--- a/ladder/teams/sig-k8s.yaml
+++ b/ladder/teams/sig-k8s.yaml
@@ -2,6 +2,7 @@ members:
 - aanm
 - christarazi
 - fristonio
+- gandro
 - ianvernon
 - joamaki
 - nathanjsweet

--- a/ladder/teams/sig-policy.yaml
+++ b/ladder/teams/sig-policy.yaml
@@ -2,6 +2,7 @@ members:
 - christarazi
 - doniacld
 - fristonio
+- gandro
 - joestringer
 - jrajahalme
 - nathanjsweet


### PR DESCRIPTION
I have been active in adjacent teams (sig-ipam for aws, helm for sig-k8s and ipcache for sig-policy) for a while.