### PR TITLE
Add release-managers team members

### DIFF
--- a/ladder/teams/release-managers.yaml
+++ b/ladder/teams/release-managers.yaml
@@ -1,0 +1,8 @@
+members:
+- aanm
+- joestringer
+- jrajahalme
+- michi-covalent
+- nathanjsweet
+- nebril
+- qmonnet


### PR DESCRIPTION
This team handles publishing Cilium releases.

Ref: https://github.com/orgs/cilium/teams/release-managers