### PR TITLE
Add yannikmesserli as a contributor to Hubble UI

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -138,6 +138,7 @@ members:
 - willfindlay
 - xmulligan
 - yandzee
+- yannikmesserli
 - youngnick
 - youssefazrak
 - ysksuzuki

--- a/ladder/teams/hubble-ui.yaml
+++ b/ladder/teams/hubble-ui.yaml
@@ -6,3 +6,4 @@ members:
 - rolinh
 - tgraf
 - yandzee
+- yannikmesserli


### PR DESCRIPTION
I request to be added to Cilium Organization as a member, as I am/will be contributing to it, especially on Hubble UI. Here are my contributions:

- [Remove wrong key lookup for service name in k8s labels](https://github.com/cilium/hubble-ui/pull/828) 
- [Remove precommit hook](https://github.com/cilium/hubble-ui/pull/801) 
- [E2E test case: test partially dropped flows](https://github.com/cilium/hubble-ui/pull/800) 
- [Check lint in PRs](https://github.com/cilium/hubble-ui/pull/791) 
- [Service map page: remove unnecessary scroll](https://github.com/cilium/hubble-ui/pull/784) 
- [Welcome screen: Allow scroll when namespaces list overflow](https://github.com/cilium/hubble-ui/pull/783)