### PR TITLE
Add Cilium Community Values

### DIFF
--- a/VALUES.md
+++ b/VALUES.md
@@ -1,0 +1,27 @@
+# Cilium Community Values
+
+The Cilium Community Values are guideposts to contributors (both new and ongoing) for how the project runs. They are meant to capture the spirit of the project of how we all work collaboratively together.
+
+## People Over Paperwork
+
+Open Source communities are built by, grow from, and thrive because of the people. Our contributors are motivated by bringing the benefits of eBPF to end users, not by filling out forms. Processes should be kept as lightweight as possible and used to benefit the people working together on or utilizing the project. Trust lies with the people working on the project.
+
+## Consensus Over Voting
+
+Keeping people at the forefront also extends to decision making. We prefer that technical issues, governance decisions, and community discussions are amicably worked out between the people involved. We only fall back on voting as a last resort.
+
+## Contribution Quality Over Quantity
+
+Cilium has its roots in the Linux kernel community where code quality is crucial. Cilium has a high technical bar to contribute because it operates in such a critical part of cloud native platforms.
+
+## Opinionated But Pragmatic
+
+Cilium’s key differentiator and unique advantage is its innovative use of eBPF technology. eBPF is the core of the project and is how we solve many cloud native challenges. However, where a particular functionality is not yet implemented in eBPF, other technologies can be utilized. eBPF everything, except exceptions.
+
+## Written Over Spoken
+
+Innovation can come at odd hours. Family situations, public holidays, and personal working times are different for all of us. We want to ensure that individual circumstances and choices do not include or exclude anyone from decisions, discussions, or information. This means striving towards asynchronous written communication ensuring inclusive discussion that does not require speaking up in a meeting, being present at an event, or being available in and monitoring Slack/Github all day.
+
+## Bottom Up Over Top Down
+
+Open source is never a straight road, but rather a meandering journey as the time, motivation, and determination of individual community members dictate. This drive from each person involved is ultimately what delivers success in the project. The work that gets done on the project is what work people decide to do rather than what they are dictated to do. The community is here to achieve great things together and help each other out, but the results still come from individual people.

--- a/VALUES.md
+++ b/VALUES.md
@@ -1,27 +1,44 @@
 # Cilium Community Values
 
-The Cilium Community Values are guideposts to contributors (both new and ongoing) for how the project runs. They are meant to capture the spirit of the project of how we all work collaboratively together.
+The Cilium Community Values are guideposts to contributors (both new and ongoing) for how the project runs.
+They are meant to capture the spirit of the project of how we all work collaboratively together.
 
 ## People Over Paperwork
 
-Open Source communities are built by, grow from, and thrive because of the people. Our contributors are motivated by bringing the benefits of eBPF to end users, not by filling out forms. Processes should be kept as lightweight as possible and used to benefit the people working together on or utilizing the project. Trust lies with the people working on the project.
+Open Source communities are built by, grow from, and thrive because of the people. Our contributors are
+motivated by bringing the benefits of eBPF to end users, not by filling out forms. Processes should be kept
+as lightweight as possible and used to benefit the people working together on or utilizing the project.
+Trust lies with the people working on the project.
 
 ## Consensus Over Voting
 
-Keeping people at the forefront also extends to decision making. We prefer that technical issues, governance decisions, and community discussions are amicably worked out between the people involved. We only fall back on voting as a last resort.
+Keeping people at the forefront also extends to decision making. We prefer that technical issues, governance
+decisions, and community discussions are amicably worked out between the people involved. We only fall
+back on voting as a last resort.
 
 ## Contribution Quality Over Quantity
 
-Cilium has its roots in the Linux kernel community where code quality is crucial. Cilium has a high technical bar to contribute because it operates in such a critical part of cloud native platforms.
+Cilium has its roots in the Linux kernel community where code quality is crucial. Cilium has a high technical
+bar to contribute because it operates in such a critical part of cloud native platforms.
 
 ## Opinionated But Pragmatic
 
-Cilium’s key differentiator and unique advantage is its innovative use of eBPF technology. eBPF is the core of the project and is how we solve many cloud native challenges. However, where a particular functionality is not yet implemented in eBPF, other technologies can be utilized. eBPF everything, except exceptions.
+Cilium's key differentiator and unique advantage is its innovative use of eBPF technology. eBPF is the
+core of the project and is how we solve many cloud native challenges. However, where a particular functionality
+is not yet implemented in eBPF, other technologies can be utilized. eBPF everything, except exceptions.
 
 ## Written Over Spoken
 
-Innovation can come at odd hours. Family situations, public holidays, and personal working times are different for all of us. We want to ensure that individual circumstances and choices do not include or exclude anyone from decisions, discussions, or information. This means striving towards asynchronous written communication ensuring inclusive discussion that does not require speaking up in a meeting, being present at an event, or being available in and monitoring Slack/Github all day.
+Innovation can come at odd hours. Family situations, public holidays, and personal working times are different
+for all of us. We want to ensure that individual circumstances and choices do not include or exclude anyone from
+decisions, discussions, or information. This means striving towards asynchronous written communication ensuring
+inclusive discussion that does not require speaking up in a meeting, being present at an event, or being available
+in and monitoring Slack/Github all day.
 
 ## Bottom Up Over Top Down
 
-Open source is never a straight road, but rather a meandering journey as the time, motivation, and determination of individual community members dictate. This drive from each person involved is ultimately what delivers success in the project. The work that gets done on the project is what work people decide to do rather than what they are dictated to do. The community is here to achieve great things together and help each other out, but the results still come from individual people.
+Open source is never a straight road, but rather a meandering journey as the time, motivation, and determination
+of individual community members dictate. This drive from each person involved is ultimately what delivers success
+in the project. The work that gets done on the project is what work people decide to do rather than what they are
+dictated to do. The community is here to achieve great things together and help each other out, but the results
+still come from individual people.


### PR DESCRIPTION
The values document lays out how Cilium works together as a project. For people new to the project, it should guide them as the best way to engage with the project (for example jumping in to solve their issues rather than waiting for it to be assigned to them) and for existing contributors it should help guide choices when ways of working need to be decided upon (for example should we implement this in eBPF)