### PR TITLE
tam: Leave helm, metrics, clustermesh and k8s teams

### DIFF
--- a/ladder/teams/helm.yaml
+++ b/ladder/teams/helm.yaml
@@ -4,6 +4,5 @@ members:
 - kaworu
 - nbusseneau
 - nebril
-- sayboras
 - seanmwinn
 - squeed

--- a/ladder/teams/metrics.yaml
+++ b/ladder/teams/metrics.yaml
@@ -3,6 +3,5 @@ members:
 - chancez
 - derailed
 - joestringer
-- sayboras
 - tommyp1ckles
 - vadorovsky

--- a/ladder/teams/sig-clustermesh.yaml
+++ b/ladder/teams/sig-clustermesh.yaml
@@ -3,6 +3,5 @@ members:
 - giorio94
 - jrajahalme
 - marseel
-- sayboras
 - tgraf
 - thorn3r

--- a/ladder/teams/sig-k8s.yaml
+++ b/ladder/teams/sig-k8s.yaml
@@ -7,7 +7,6 @@ members:
 - joamaki
 - nathanjsweet
 - nebril
-- sayboras
 - squeed
 - tgraf
 - tommyp1ckles


### PR DESCRIPTION
There are more team members, who are having more knowledge and work on these components day by day.