### PR TITLE
Request to add dlapcevic to sig-scalability

### DIFF
--- a/ladder/teams/sig-scalability.yaml
+++ b/ladder/teams/sig-scalability.yaml
@@ -1,4 +1,5 @@
 members:
+- dlapcevic
 - giorio94
 - learnitall
 - marseel


### PR DESCRIPTION
I've been working on Cilium scalability, mostly related to network policies:
- https://github.com/cilium/cilium/issues/31457
- https://github.com/cilium/cilium/issues/33360

I want to and think it would be good to get involved more in the development of these areas.