### PR TITLE
Request to add dlapcevic to sig-policy

### DIFF
--- a/ladder/teams/sig-policy.yaml
+++ b/ladder/teams/sig-policy.yaml
@@ -1,6 +1,7 @@
 members:
 - christarazi
 - derailed
+- dlapcevic
 - doniacld
 - fristonio
 - gandro


### PR DESCRIPTION
I've been working on Cilium scalability, mostly related to network policies:
- https://github.com/cilium/cilium/issues/31457
- https://github.com/cilium/cilium/issues/33360

I want to and think it would be good to get involved more in the development of these areas.