### PR TITLE
Request to add learnitall to CI role

### DIFF
--- a/roles/CI-Team.md
+++ b/roles/CI-Team.md
@@ -4,3 +4,5 @@ The CI team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CON
 
 * [Nicolas Busseneau](https://github.com/nbusseneau)
 * [Birol Bilgin](https://github.com/brlbil)
+* [Ryan Drew](https://github.com/learnitall)
+


### PR DESCRIPTION
Hey folks! I'd like to request membership in the CI team role. I've been working for the past couple of months with @brb to improve our CI Health dashboards and processes. It's been a lot of fun, and I'd like to make the responsibility a bit more official. Thanks!