### PR TITLE
Format Maintainers.md

### DIFF
--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -2,40 +2,49 @@
 
 The Maintainers roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#maintainers). The following are the current maintainers:
 
-## Cilium
+## [cilium-maintainers]: Maintainers of https://github.com/cilium/cilium
 
 * [Joe Stringer](https://github.com/joestringer)
 * [André Martins](https://github.com/aanm)
 
-## cilium-cli
+## [cilium-cli-maintainers]: Maintainers of https://github.com/cilium/cilium-cli
 
 * [Tobias Klauser](https://github.com/tklauser)
 * [Michi Mutsuzaki](https://github.com/michi-covalent)
 
-## Hubble
+## [hubble-maintainers]: Maintainers of https://github.com/cilium/hubble
 
 * [Glib Smaga](https://github.com/glibsm)
 * [Sebastian Wicki](https://github.com/gandro)
 
-## Tetragon
+## [tetragon-maintainers]: Maintainers of https://github.com/cilium/tetragon
 
 * [Natália Réka Ivánkó](https://github.com/sharlns)
 * [John Fastabend](https://github.com/jrfastab)
 
-## proxy
+## [proxy-maintainers]: Maintainers of https://github.com/cilium/proxy
 
 * [Tam Mach](https://github.com/sayboras)
 * [Jarno Rajahalme](https://github.com/jrajahalme)
 
-## ebpf
+## [ebpf-lib-maintainers]: Maintainers of https://github.com/cilium/ebpf
 
 * [Lorenz Bauer](https://github.com/lmb)
 * [Timo Beckers](https://github.com/ti-mo)
 
-## cilium.io
+## [cilium.io-maintainers]: Maintainers of https://github.com/cilium/cilium.io
 
 * [Bill Mulligan](https://github.com/xmulligan)
 
-## pwru
+## [pwru-maintainers]: Maintainers of https://github.com/cilium/pwru
 
 * [Martynas Pumputis](https://github.com/brb)
+
+[cilium-cli-maintainers]: https://github.com/orgs/cilium/teams/cilium-cli-maintainers
+[cilium-maintainers]: https://github.com/orgs/cilium/teams/cilium-maintainers
+[cilium.io-maintainers]: https://github.com/orgs/cilium/teams/cilium-io-maintainers
+[ebpf-lib-maintainers]: https://github.com/orgs/cilium/teams/ebpf-lib-maintainers
+[hubble-maintainers]: https://github.com/orgs/cilium/teams/hubble-maintainers
+[proxy-maintainers]: https://github.com/orgs/cilium/teams/proxy-maintainers
+[pwru-maintainers]: https://github.com/orgs/cilium/teams/pwru-maintainers
+[tetragon-maintainers]: https://github.com/orgs/cilium/teams/tetragon-maintainers


### PR DESCRIPTION
Add links to GitHub teams and repositories to make it grep-friendly to find which teams maintain which repositories.