### PR TITLE
Update teams for Quentin

### DIFF
--- a/ladder/teams/ipsec.yaml
+++ b/ladder/teams/ipsec.yaml
@@ -5,6 +5,5 @@ members:
 - jschwinger233
 - julianwiedmann
 - pchaigno
-- qmonnet
 - rgo3
 - tommyp1ckles

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -22,7 +22,6 @@ members:
 - nathanjsweet
 - nirmoy
 - pchaigno
-- qmonnet
 - rastislavs
 - tommyp1ckles
 - vadorovsky

--- a/ladder/teams/sig-lb.yaml
+++ b/ladder/teams/sig-lb.yaml
@@ -8,5 +8,4 @@ members:
 - joamaki
 - jschwinger233
 - julianwiedmann
-- qmonnet
 - ysksuzuki


### PR DESCRIPTION
I don't expect to have much time for technical reviews for Cilium in the foreseeable future. Removing myself from `ipsec`, `sig-datapath`, and `sig-lb` teams.
