### PR TITLE
feat: add Artyop to organisation members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -11,6 +11,7 @@ members:
 - anfernee
 - anubhabMajumdar
 - aojea
+- Artyop
 - asauber
 - aspsk
 - b3a-dev


### PR DESCRIPTION
Following contributions on the CI in cilium/cilium [(34372)](https://github.com/cilium/cilium/pull/34372) and the renovate fix on cilium/image-tools [(286)](https://github.com/cilium/image-tools/pull/286) I would like to be added to the org members in order to continue maintaining and improving the CI.