### PR TITLE
Add DamianSawicki to organization members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -1,4 +1,5 @@
 members:
+- DamianSawicki
 - Neelajacques
 - NikAleksandrov
 - PhilipSchmid


### PR DESCRIPTION
Add Damian Sawicki (@DamianSawicki) to org members to make it easier to test future (and ongoing) PRs.  [Contributions to date](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3ADamianSawicki).