### PR TITLE
add rectified95 to new hubble-metrics group

### DIFF
--- a/ladder/teams/hubble-metrics.yaml
+++ b/ladder/teams/hubble-metrics.yaml
@@ -1,0 +1,5 @@
+members:
+- chancez
+- gandro
+- rectified95
+- rolinh


### PR DESCRIPTION
Listing new sig for the metrics portion of Hubble and adding myself as reviewer.
Related contributions: https://github.com/cilium/cilium/pulls/rectified95