### PR TITLE
refac: change reviewer process PR doc

### DIFF
--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -121,7 +121,7 @@ Reviewers have all the rights and responsibilities of an Organization Member, pl
 
 The process for an Organization Member to become a Reviewer is as follows:
 
-1. Open a PR in the member management file for [at least two teams](ladder/teams): "Reviewers" and for a specific review area
+1. Open a PR in the member management file for [at least two teams](ladder/teams), each assigned to a specific review area.
 2. At least two members who are already Committers, approve the PR
 
 Automated tooling assigns PRs across the Reviewers defined for each particular area. 


### PR DESCRIPTION
A bit of a nitpick, but at first when I read the reviewer process I thought I needed to add myself to a team named "Reviewer". This commit is just to clarify the fact that you need two different specific review area teams for becoming reviewer.