### PR TITLE
teams: Remove learnitall from multiple teams

### DIFF
--- a/ladder/teams/api.yaml
+++ b/ladder/teams/api.yaml
@@ -1,5 +1,4 @@
 members:
 - aanm
-- learnitall
 - nathanjsweet
 - vadorovsky

--- a/ladder/teams/docs-structure.yaml
+++ b/ladder/teams/docs-structure.yaml
@@ -1,6 +1,5 @@
 members:
 - joestringer
 - lambdanis
-- learnitall
 - qmonnet
 - zacharysarah

--- a/ladder/teams/metrics.yaml
+++ b/ladder/teams/metrics.yaml
@@ -3,6 +3,5 @@ members:
 - chancez
 - derailed
 - joestringer
-- learnitall
 - tommyp1ckles
 - vadorovsky

--- a/ladder/teams/sig-scalability.yaml
+++ b/ladder/teams/sig-scalability.yaml
@@ -1,6 +1,5 @@
 members:
 - dlapcevic
 - giorio94
-- learnitall
 - marseel
 - thorn3r

--- a/ladder/teams/vendor.yaml
+++ b/ladder/teams/vendor.yaml
@@ -1,6 +1,5 @@
 members:
 - aanm
-- learnitall
 - marseel
 - ovidiutirla
 - sayboras

--- a/roles/CI-Team.md
+++ b/roles/CI-Team.md
@@ -2,7 +2,5 @@
 
 The CI team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](/CONTRIBUTOR-ROLES.md#ci-team). The following are the current CI team members:
 
-* [Nicolas Busseneau](https://github.com/nbusseneau)
-* [Birol Bilgin](https://github.com/brlbil)
-* [Ryan Drew](https://github.com/learnitall)
-
+- [Nicolas Busseneau](https://github.com/nbusseneau)
+- [Birol Bilgin](https://github.com/brlbil)


### PR DESCRIPTION
I'm shifting gears in my career away from Cilium, and will, for at least the time being, no longer have the availability to perform the responsibilities required for the teams that I've been assigned to.

Thank you for letting me be a part of these teams, I've enjoyed my time on them! Maybe I can come back at some point, but for right now I think it's best if I'm removed, thanks.