### PR TITLE
ladder: Fix reviewer process

### DIFF
--- a/CONTRIBUTOR-LADDER.md
+++ b/CONTRIBUTOR-LADDER.md
@@ -121,7 +121,7 @@ Reviewers have all the rights and responsibilities of an Organization Member, pl
 
 The process for an Organization Member to become a Reviewer is as follows:
 
-1. Open a PR in the member management file for [at least two teams](ladder/teams), each assigned to a specific review area.
+1. Open a PR in the member management file for [the corresponding team](ladder/teams) assigned to a specific review area.
 2. At least two members who are already Committers, approve the PR
 
 Automated tooling assigns PRs across the Reviewers defined for each particular area. 


### PR DESCRIPTION
Commit ee7eea33e604d removed reference to one of the teams, but kept the
process as requiring membership in two teams. There is no such
requirement to be a reviewer in multiple teams, the other team was
intended to be the general "reviewer" group. Since we don't have a
dedicated file for all reviewers currently, we don't need to mention the
other team. Make the steps make sense.
