### PR TITLE
Add team-management automation tooling to community repo

### DIFF
--- a/.github/workflows/team-updates.yaml
+++ b/.github/workflows/team-updates.yaml
@@ -1,0 +1,24 @@
+name: Team Updates
+on:
+
+  # enable manual trigger via github actions interface
+  workflow_dispatch:
+
+  # trigger on push to main branch
+  push:
+    branches:
+      - main
+
+jobs:
+  # Send a cross-repository workflow dispatch request to the team-management repo
+  # Team management repo workflow will take action on event_type community_teams_update
+  dispatch-team-management:
+    if: github.repository == 'cilium/community'
+    name: Dispatch Team Management
+    runs-on: ubuntu-latest
+    environment: team-management  
+    steps:
+      # Send the workflow dispatch event via GitHUB API
+      - name: Dispatch workflow request
+        run: |
+          curl --fail-with-body -L -XPOST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{secrets.TM_DISPATCH_TOKEN}}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/cilium/team-management/dispatches -d '{"event_type":"community_teams_update"}'

--- a/tools/aggregate_team_overrides.sh
+++ b/tools/aggregate_team_overrides.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+##
+# This script is used to generate an aggregate team membership
+# file based on a directory of yaml files of the 
+# form team-name.yaml
+# This tool is used as part of team-management automation
+##
+
+set -eu
+set -o pipefail
+
+# $1 - teams directory
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <TEAMS_DIRECTORY>"
+  exit 1
+fi
+
+>&2 echo "> Aggregating Teams from $1/*.yaml"
+
+cd "$1"
+echo "teams:" 
+for file in *.yaml; do
+     >&2 echo ">> Processing: $file"
+     f="${file%.*}"
+     echo "  $f:" 
+     sed 's/^/    /' "$file" 
+done
+


### PR DESCRIPTION
This PR adds two files

1. a helper script in tools/ directory that will aggregate the directory of per-team yaml files into a single yaml file that can be processed by the team management tool.

2. A github workflow that will send a cross-repository workflow dispatch event to the private team-management repo. 

This PR should be committed prior to the related/inbound team-management repository PR that implments the workflow that will catch the cross-repo workflow dispatch event sent by the workflow here.

Until the team-management repo workflow is in place, this is effectively a noop, but the workflow should operate to completion and send an dispatch event, if the token and repository permissions have been setup adequately. So I'd like to get this committed and test to make sure it works before the related team-management PR is committed and operational.