### PR TITLE
Add PR template for moving up the contributor ladder

### DIFF
--- a/ladder/pull_request_template.md
+++ b/ladder/pull_request_template.md
@@ -1,0 +1,24 @@
+# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
+
+```
+## Adding Yourself as an [Org Member](https://github.com/cilium/community/blob/main/ladder/members.yaml)
+If this pull request is to add yourself to the Cilium Organization:
+1. Review the [qualifications](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member)
+2. Add a list of your previous contributions to the pull request description. This helps reviewers understand your involvement and context
+
+## Adding Yourself as a Reviewer
+If this pull request is to add yourself as a [reviewer for a specific team](https://github.com/cilium/community/tree/main/ladder/teams):
+1. Ensure that you are already a Cilium Org Member
+2. Review the [qualifications](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#reviewer)
+3. Add a list of your previous contributions to the pull request description. This helps reviewers understand your involvement and context
+```
+   
+## My Relevant Contributions to the Cilium Project:
+- Link to issues you have opened. Check this with https://github.com/cilium/cilium/issues?q=is%3Aissue+author%3AGITHUB-USER-ID
+- Link to pull requests you have reviewed. Check this with https://github.com/cilium/cilium/pulls?q=is%3Apr+reviewed-by%3AGITHUB-USER-ID
+- Link to pull requests you have authored. Check this with https://github.com/cilium/cilium/pulls?q=is%3Aopen%7Cclosed+author%3AGITHUB-USER-ID
+- Links to discussions or issues you actively participated in
+- Other relevant community involvement
+
+## Additional Notes
+Add any other information or context for the reviewers


### PR DESCRIPTION
PR template for people requesting to become org members and reviewers to clarify what information is helpful when opening the PR

As discussed in https://github.com/cilium/community/pull/180#issuecomment-2576257561