### PR TITLE
small fix to team aggregation tool to address file reading without newline at the end of file

### DIFF
--- a/tools/aggregate_team_overrides.sh
+++ b/tools/aggregate_team_overrides.sh
@@ -26,6 +26,8 @@ for file in *.yaml; do
      >&2 echo ">> Processing: $file"
      f="${file%.*}"
      echo "  $f:" 
-     sed 's/^/    /' "$file" 
+     sed 's/^/    /' "$file"
+     #Add one blank line after each team just to make sure it exists"
+     echo "" 
 done
 


### PR DESCRIPTION
Cornercase in the team yaml file processes I didn't catch.

Fix is to add an explict newline between team files in the aggregate, to ensure correct yaml syntax.