### PR TITLE
Nominating antonipp and mvisonneau as org members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -9,6 +9,7 @@ members:
 - aditighag
 - alan-kut
 - anfernee
+- antonipp
 - anubhabMajumdar
 - aojea
 - Artyop
@@ -95,6 +96,7 @@ members:
 - michi-covalent
 - mmat11
 - mtardy
+- mvisonneau
 - mythi
 - nathanjsweet
 - nbusseneau


### PR DESCRIPTION
@antonipp and @mvisonneau have been contributing to the Cilium project for a while now. They've also been very active in sharing learnings with the community through multiple CiliumCon talks.

For ref, here are the contributions from [Maxime](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Amvisonneau+is%3Amerged+) and [Anton](https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Aantonipp+is%3Amerged+)