### PR TITLE
Add haozhangami to organization members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -49,6 +49,7 @@ members:
 - glibsm
 - glrf
 - hacktivist123
+- haozhangami
 - harsimran-pabla
 - hemanthmalla
 - hhoover


### PR DESCRIPTION
I would like to be an organization member to contribute more effectively, have access to CI commands, and keep growing within this community.

Previous contributions:

PRs: https://github.com/cilium/cilium/pulls?q=is%3Apr+author%3Ahaozhangami