### PR TITLE
Remove myself from @cilium/sig-hubble

### DIFF
--- a/ladder/teams/sig-hubble.yaml
+++ b/ladder/teams/sig-hubble.yaml
@@ -7,4 +7,3 @@ members:
 - kaworu
 - michi-covalent
 - rolinh
-- tklauser


### PR DESCRIPTION
Unfortunately I no longer have the cycles to review Hubble changes.