### PR TITLE
Add PR template for moving up the contributor ladder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,11 @@
+# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
+   
+## My Relevant Contributions to the Cilium Project:
+- [ ] Link to issues you have opened. Check this with https://github.com/cilium/cilium/issues?q=is%3Aissue+author%3AGITHUB-USER-ID
+- [ ] Link to pull requests you have reviewed. Check this with https://github.com/cilium/cilium/pulls?q=is%3Apr+reviewed-by%3AGITHUB-USER-ID
+- [ ] Link to pull requests you have authored. Check this with https://github.com/cilium/cilium/pulls?q=is%3Aopen%7Cclosed+author%3AGITHUB-USER-ID
+- [ ] Links to discussions or issues you actively participated in
+- [ ] Other relevant community involvement
+
+## Additional Notes
+Add any other information or context for the reviewers


### PR DESCRIPTION
PR template for people requesting to become org members and reviewers to clarify what information is helpful when opening the PR

Supersedes #190 and #191

I’ve considered various approaches to formatting this but landed on the current one for simplicity. Initially, I thought about making this an issue template, but requiring contributors to open an issue before a PR felt unnecessarily complex and could lead to confusion.

For reference, #190 included an additional top section that I’ve since removed, as it added extra wording without providing new information beyond what’s already covered in the ladder.

I also explored creating multiple templates, but that seemed confusing too—contributors would need to know the correct URLs for each template. This solution isn’t perfect since it applies to the entire repository, including SIGs and sub-repositories. However, I expect external contributors to interact with those less frequently, and internal contributors will likely bypass the template where necessary.