### PR TITLE
add smagnani96 to sig-encryption, wireguard, and ipsec

### DIFF
--- a/ladder/teams/ipsec.yaml
+++ b/ladder/teams/ipsec.yaml
@@ -6,4 +6,5 @@ members:
 - ldelossa
 - pchaigno
 - rgo3
+- smagnani96
 - tommyp1ckles

--- a/ladder/teams/sig-encryption.yaml
+++ b/ladder/teams/sig-encryption.yaml
@@ -6,3 +6,4 @@ members:
 - jrfastab
 - jschwinger233
 - pchaigno
+- smagnani96

--- a/ladder/teams/wireguard.yaml
+++ b/ladder/teams/wireguard.yaml
@@ -2,3 +2,4 @@ members:
 - brb
 - gandro
 - jschwinger233
+- smagnani96


### PR DESCRIPTION
From the time I started contributing to the Cilium codebase, I've been focussing on both datapath and control plane for IPSec and Wireguard. As I plan to continue contributing to this area of expertise, I'd kindly ask to add myself to these teams, so that I can also provide my feedback and insights in reviews.