### PR TITLE
Remove inactive reviewers

### DIFF
--- a/ladder/teams/egress-gateway.yaml
+++ b/ladder/teams/egress-gateway.yaml
@@ -1,7 +1,6 @@
 members:
 - jibi
 - julianwiedmann
-- lmb
 - pchaigno
 - pippolo84
 - ysksuzuki

--- a/ladder/teams/loader.yaml
+++ b/ladder/teams/loader.yaml
@@ -1,5 +1,4 @@
 members:
 - dylandreimerink
-- lmb
 - rgo3
 - ti-mo

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -18,7 +18,6 @@ members:
 - julianwiedmann
 - kkourt
 - ldelossa
-- markpash
 - nirmoy
 - pchaigno
 - rastislavs


### PR DESCRIPTION
During the transition of backend tooling, we identified these members
who were in practice not part of the teams although the community repo
stated they are expected to provide reviews for the corresponding teams.
As far as I can tell they no longer primarily focus on Cilium in their
day-to-day development so I don't want to re-impose expectations for
reviews upon them unless they actively signal that they would like to
return to reviewer status for these teams. Thus, remove them for now.

@lmb, @markpash feel free to send a revert PR if you would like to
re-join these teams.
