### PR TITLE
members: Fix capitalization for members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -1,5 +1,6 @@
 members:
 - DamianSawicki
+- JamesLaverack
 - Neelajacques
 - NikAleksandrov
 - PhilipSchmid
@@ -57,7 +58,6 @@ members:
 - husnialhamdani
 - ianvernon
 - jaffcheng
-- jameslaverack
 - jeefy
 - jelonka
 - jibi


### PR DESCRIPTION
These members were identified as having incorrect capitalization for
their usernames in the members file, as compared with their true
username on GitHub. Fix them so that the synchronization to the upstream
GitHub organization works correctly.
