### PR TITLE
Add Kyle to Security team for CodeQL Scanning Access

### DIFF
--- a/roles/Security-Team.md
+++ b/roles/Security-Team.md
@@ -15,3 +15,4 @@ The security team roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md
 * [Liz Rice](https://github.com/lizrice)
 * [Tam Mach](https://github.com/sayboras)
 * [Feroz Salam](https://github.com/ferozsalam)
+* [Kyle Simmons](https://github.com/kyle-c-simmons)


### PR DESCRIPTION
As discussed offline I am configuring CodeQL scanning for the Github repositories and require access to the Security role to triage the findings.

## My Relevant Contributions to the Cilium Project:
N/A
## Additional Notes
N/A