### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 # Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
    
-## My Relevant Contributions to the Cilium Project:
-- [ ] Link to issues you have opened. Check this with https://github.com/cilium/cilium/issues?q=is%3Aissue+author%3AGITHUB-USER-ID
-- [ ] Link to pull requests you have reviewed. Check this with https://github.com/cilium/cilium/pulls?q=is%3Apr+reviewed-by%3AGITHUB-USER-ID
-- [ ] Link to pull requests you have authored. Check this with https://github.com/cilium/cilium/pulls?q=is%3Aopen%7Cclosed+author%3AGITHUB-USER-ID
+## My Relevant Contributions to the Cilium Ecosystem:
+- [ ] Link to issues you have opened. Check this [here](https://github.com/search?q=org%3Acilium+author%3A%40me+&type=issues)
+- [ ] Link to pull requests you have reviewed. Check this [here](https://github.com/search?q=org%3Acilium+reviewed-by%3A%40me&type=pullrequests)
+- [ ] Link to pull requests you have authored. Check this [here](https://github.com/search?q=org%3Acilium+author%3A%40me&type=pullrequests)
 - [ ] Links to discussions or issues you actively participated in
 - [ ] Other relevant community involvement
 


### PR DESCRIPTION
Update the PR template:
* Replace "cilium project" with "cilium ecosystem" (see #146)
* Update issues/PRs query links:
  * Make them scoped to the cilium github org instead of just the cilium/cilium github project
  * Replace the `GITHUB-USER-ID` placeholder with the `@me` shorthand which makes the links work without needing to manually edit them


Updated PR template looks like [this](https://github.com/HadrienPatte/community/blob/2d1c39efac7df688df1f400d9a9d8e5699880bf1/.github/pull_request_template.md):
<img width="586" alt="image" src="https://github.com/user-attachments/assets/619b2817-b376-411c-ac48-1711f50fc4a6" />