### PR TITLE
cleanup: Remove lambdanis from docs-structure

### DIFF
--- a/ladder/teams/docs-structure.yaml
+++ b/ladder/teams/docs-structure.yaml
@@ -1,5 +1,4 @@
 members:
 - joestringer
-- lambdanis
 - qmonnet
 - zacharysarah


### PR DESCRIPTION
I'll be now working on different things and I don't have capacity for Cilium
contributions anymore, so removing myself from the cilium/docs-structure team.

I might be not fully up-to-date with the process and tooling, so please let me
know if I need to make other changes. Retaining permissions in the Tetragon
repo would be helpful for me, but if it's not possible, I'll be fine too. I
don't need anything else, and I would prefer to be removed from unnecessary
teams.