### PR TITLE
teams: Update membership for joestringer

### DIFF
--- a/ladder/teams/alibabacloud.yaml
+++ b/ladder/teams/alibabacloud.yaml
@@ -2,4 +2,3 @@ members:
 - aanm
 - christarazi
 - doniacld
-- joestringer

--- a/ladder/teams/ipcache.yaml
+++ b/ladder/teams/ipcache.yaml
@@ -3,8 +3,9 @@ members:
 - christarazi
 - doniacld
 - gandro
-- joestringer
 - jrajahalme
 - jrfastab
 - squeed
 - tklauser
+mentors:
+- joestringer

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -11,7 +11,6 @@ members:
 - harsimran-pabla
 - jibi
 - joamaki
-- joestringer
 - jrfastab
 - jschwinger233
 - julianwiedmann
@@ -21,3 +20,5 @@ members:
 - rastislavs
 - tommyp1ckles
 - ysksuzuki
+mentors:
+- joestringer

--- a/ladder/teams/sig-encryption.yaml
+++ b/ladder/teams/sig-encryption.yaml
@@ -2,7 +2,6 @@ members:
 - brb
 - christarazi
 - gandro
-- joestringer
 - jrfastab
 - jschwinger233
 - pchaigno

--- a/ladder/teams/sig-policy.yaml
+++ b/ladder/teams/sig-policy.yaml
@@ -4,9 +4,10 @@ members:
 - derailed
 - doniacld
 - gandro
-- joestringer
 - jrajahalme
 - nathanjsweet
 - nebril
 - squeed
 - tklauser
+mentors:
+- joestringer


### PR DESCRIPTION
Update my membership to more accurately reflect my involvement in different areas of the Cilium project.

Notable changes:
- @cilium/alibabacloud: Removing myself as I'm not familiar with this code.
- @cilium/sig-encryption: My role was more of a fallback here, I trust the newer members to uphold the quality.

I've shifted myself to "mentor" in a few teams to reflect that I am happy to step in and provide guidance as needed, but on a day-to-day basis I am typically contributing elsewhere. For the remaining teams, I'll remain on the regular rotation to help spread the review load.
