### PR TITLE
teams: Remove vagrant team

### DIFF
--- a/ladder/teams/vagrant.yaml
+++ b/ladder/teams/vagrant.yaml
@@ -1,5 +1,0 @@
-members:
-- aanm
-- nbusseneau
-- nebril
-- pchaigno


### PR DESCRIPTION
We removed vagrant as a tool from cilium/cilium quite some time ago, no
need to have a team to manage this area any more.

cc @cilium/vagrant
