### PR TITLE
teams: Fix mentors syntax

### DIFF
--- a/ladder/teams/ipcache.yaml
+++ b/ladder/teams/ipcache.yaml
@@ -3,6 +3,7 @@ members:
 - christarazi
 - doniacld
 - gandro
+- joestringer
 - jrajahalme
 - jrfastab
 - squeed

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -11,6 +11,7 @@ members:
 - harsimran-pabla
 - jibi
 - joamaki
+- joestringer
 - jrfastab
 - jschwinger233
 - julianwiedmann

--- a/ladder/teams/sig-policy.yaml
+++ b/ladder/teams/sig-policy.yaml
@@ -4,6 +4,7 @@ members:
 - derailed
 - doniacld
 - gandro
+- joestringer
 - jrajahalme
 - nathanjsweet
 - nebril


### PR DESCRIPTION
The cilium/team-manager tool that parses these files expects that
mentors are also listed in the members field of the team. Fix up these
references.

Fixes: 036dd77a354c ("teams: Update membership for joestringer")
