### PR TITLE
teams: add rgo3 to egress-gateway and encryption teams

### DIFF
--- a/ladder/teams/egress-gateway.yaml
+++ b/ladder/teams/egress-gateway.yaml
@@ -3,5 +3,6 @@ members:
 - julianwiedmann
 - pchaigno
 - pippolo84
+- rgo3
 - tommyp1ckles
 - ysksuzuki

--- a/ladder/teams/sig-encryption.yaml
+++ b/ladder/teams/sig-encryption.yaml
@@ -5,4 +5,5 @@ members:
 - jrfastab
 - jschwinger233
 - pchaigno
+- rgo3
 - smagnani96

--- a/ladder/teams/wireguard.yaml
+++ b/ladder/teams/wireguard.yaml
@@ -2,4 +2,5 @@ members:
 - brb
 - gandro
 - jschwinger233
+- rgo3
 - smagnani96


### PR DESCRIPTION
After my somewhat recent IPv6 extension to the egress gateway feature I should have enough knowledge to help out with reviews in that area. Additionally, I've added myself to the overall encryption and wireguard teams after realizing I've only been part of the ipsec team so far.

cc @julianwiedmann 
