### PR TITLE
Add HadrienPatte to `build` and `vendor` teams

### DIFF
--- a/ladder/teams/build.yaml
+++ b/ladder/teams/build.yaml
@@ -1,4 +1,5 @@
 members:
+- HadrienPatte
 - aanm
 - borkmann
 - gentoo-root

--- a/ladder/teams/vendor.yaml
+++ b/ladder/teams/vendor.yaml
@@ -1,4 +1,5 @@
 members:
+- HadrienPatte
 - aanm
 - marseel
 - ovidiutirla


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:

### `build` related contributions:
* https://github.com/cilium/cilium/issues/40000
* https://github.com/cilium/cilium/pull/37716
* https://github.com/cilium/cilium/pull/38288
* https://github.com/cilium/cilium/pull/38322

### `vendor` related contributions:
* https://github.com/cilium/cilium/issues/39235
* https://github.com/cilium/cilium/pull/36751
* https://github.com/cilium/cilium/pull/37087
* Various depreciated libraries/methods updates (https://github.com/cilium/cilium/pull/37098, https://github.com/cilium/cilium/pull/37167, https://github.com/cilium/cilium/pull/39335, https://github.com/cilium/cilium/pull/39364)

## Additional Notes

Being reviewer would also be helpful for work on base images in the context of https://github.com/cilium/cilium/issues/40000 as it grants write privileges (see https://github.com/cilium/cilium/pull/39996#issuecomment-2971499742).