### PR TITLE
members: Add Kateryna

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -89,6 +89,7 @@ members:
 - nathanjsweet
 - nbusseneau
 - nebril
+- nezdolik
 - nickolaev
 - nirmoy
 - nvibert


### PR DESCRIPTION
Add Kateryna Nezdolii as a member so that she can trigger CI and we can solicite reviews from her. While she has no Cilium contributions yet, her upstream Envoy contributions qualify her to contribute to cilium/proxy repository.
