### PR TITLE
teams: remove Robin from build team

### DIFF
--- a/ladder/teams/build.yaml
+++ b/ladder/teams/build.yaml
@@ -6,7 +6,6 @@ members:
 - joestringer
 - michi-covalent
 - nebril
-- rolinh
 - thorn3r
 - tklauser
 - tommyp1ckles


### PR DESCRIPTION
I'm looking to reduce my review load so that I can focus more on Hubble overall.
