### PR TITLE
Add asauber to release-managers

### DIFF
--- a/ladder/teams/release-managers.yaml
+++ b/ladder/teams/release-managers.yaml
@@ -1,5 +1,6 @@
 members:
 - aanm
+- asauber
 - gentoo-root
 - joestringer
 - jrajahalme


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:
- [x] Link to [issues you have opened](https://github.com/search?q=org%3Acilium+author%3Aasauber&type=issues).
- [x] Link to pull requests you have authored. Check this [here](https://github.com/search?q=org%3Acilium+author%3Aasauber&type=pullrequests)
- [x] Other relevant community involvement

I have actively participated as a Release Manager for the Cilium project for more than two years. Adding myself to the `release-managers` team.
