### PR TITLE
Add tsotne95 as org member

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -125,6 +125,7 @@ members:
 - tklauser
 - tommyp1ckles
 - tpapagian
+- tsotne95
 - tvonhacht-apple
 - ungureanuvladvictor
 - vadorovsky


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)

Proposing to add @tsotne95 as an org member. He is actively contributing to the Cilium load-balancer implementation.
 
## Relevant Contributions to the Cilium Ecosystem:
- https://github.com/cilium/cilium/pull/40095
- https://github.com/cilium/cilium/pull/39833
