### PR TITLE
teams: Add cilium-io team for cilium.io repo reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 /ladder/teams/azure.yaml @cilium/azure
 /ladder/teams/build.yaml @cilium/build
 /ladder/teams/ci-structure.yaml @cilium/ci-structure
+/ladder/teams/cilium-io.yaml @cilium/cilium-io
 /ladder/teams/cli.yaml @cilium/cli
 /ladder/teams/contributing.yaml @cilium/contributing
 /ladder/teams/docker.yaml @cilium/docker

--- a/ladder/reviewers.yaml
+++ b/ladder/reviewers.yaml
@@ -16,6 +16,7 @@ reviewers:
 - christarazi
 - ciliumbot
 - derailed
+- doniacld
 - dylandreimerink
 - ferozsalam
 - fristonio
@@ -36,8 +37,10 @@ reviewers:
 - kaworu
 - kevsecurity
 - kkourt
+- krmeinders
 - ldelossa
 - liyihuang
+- lizrice
 - marseel
 - mhofstetter
 - michi-covalent
@@ -46,6 +49,7 @@ reviewers:
 - nebril
 - olsajiri
 - ovidiutirla
+- paularah
 - pchaigno
 - pippolo84
 - qmonnet
@@ -60,6 +64,7 @@ reviewers:
 - squeed
 - tamilmani1989
 - tgraf
+- thebsdbox
 - thorn3r
 - ti-mo
 - tixxdz
@@ -69,6 +74,7 @@ reviewers:
 - ungureanuvladvictor
 - viktor-kurchenko
 - will-isovalent
+- xmulligan
 - yandzee
 - yannikmesserli
 - youngnick

--- a/ladder/teams/cilium-io.yaml
+++ b/ladder/teams/cilium-io.yaml
@@ -1,0 +1,7 @@
+members:
+- doniacld
+- krmeinders
+- lizrice
+- paularah
+- thebsdbox
+- xmulligan


### PR DESCRIPTION
This PR adds the `cilium-io` team to manage reviews for the `cilium.io` repository. This dedicated group helps clarify ownership and streamline the review process. It ensures that the right people are notified for content and community-related updates.

cc @xmulligan 