### PR TITLE
members: Add krmeinders to members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -65,6 +65,7 @@ members:
 - kaworu
 - kevsecurity
 - kkourt
+- krmeinders
 - kvaps
 - kyle-c-simmons
 - lbernail


### PR DESCRIPTION
Katie Meinders will soon be an active member of the Community team. She
contributes to community content, outreach, and open source engagement around
Cilium and related projects. Adding her to the members ensures she has the
appropriate access and visibility to collaborate on repositories like
cilium.io, and to participate in content and community-related reviews.