### PR TITLE
members: Add thebsdbox to members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -118,6 +118,7 @@ members:
 - sypakine
 - tamilmani1989
 - tgraf
+- thebsdbox
 - thelinuxfoundation
 - thorn3r
 - ti-mo


### PR DESCRIPTION
Dan is an active member of the Community team and regularly contributes to community content, outreach, and open source engagement around Cilium and related projects. This addition ensures they have the appropriate access and visibility for reviewing and collaborating on repositories like cilium.io.

cc @xmulligan 