### PR TITLE
Revert "members: Add krmeinders to members"

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -65,7 +65,6 @@ members:
 - kaworu
 - kevsecurity
 - kkourt
-- krmeinders
 - kvaps
 - kyle-c-simmons
 - lbernail


### PR DESCRIPTION
Reverts cilium/community#275

I'm going to revert this since it didn't follow the process for adding members to the org https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member