### PR TITLE
Revert "members: Add thebsdbox to members"

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -120,7 +120,6 @@ members:
 - sypakine
 - tamilmani1989
 - tgraf
-- thebsdbox
 - thelinuxfoundation
 - thorn3r
 - ti-mo


### PR DESCRIPTION
This reverts commit a8001717823d31516666d4f1d895ab953c5fab2b.

I'm going to revert this since it didn't follow the process for adding members to the org https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md#organization-member
