### PR TITLE
Improve reviewer / member linting

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -2,6 +2,7 @@ members:
 - AritraDey-Dev
 - Artyop
 - DamianSawicki
+- ExceptionalHandler
 - HadrienPatte
 - JamesLaverack
 - MrFreezeex
@@ -35,7 +36,6 @@ members:
 - dswaffordcw
 - dylandreimerink
 - eloycoto
-- ExceptionalHandler
 - f1ko
 - ferozsalam
 - florianl

--- a/ladder/reviewers.yaml
+++ b/ladder/reviewers.yaml
@@ -37,7 +37,6 @@ reviewers:
 - kaworu
 - kevsecurity
 - kkourt
-- krmeinders
 - ldelossa
 - liyihuang
 - lizrice
@@ -64,7 +63,6 @@ reviewers:
 - squeed
 - tamilmani1989
 - tgraf
-- thebsdbox
 - thorn3r
 - ti-mo
 - tixxdz

--- a/ladder/teams/cilium-io.yaml
+++ b/ladder/teams/cilium-io.yaml
@@ -1,7 +1,5 @@
 members:
 - doniacld
-- krmeinders
 - lizrice
 - paularah
-- thebsdbox
 - xmulligan

--- a/tools/generate-reviewers.sh
+++ b/tools/generate-reviewers.sh
@@ -6,13 +6,17 @@ set -eu
 
 REVIEWERS="ladder/reviewers.yaml"
 
-function main() {
+function build_reviewer_list() {
     echo "reviewers:" > $REVIEWERS
     for f in ladder/teams/*.yaml; do
         yq '.members' "$f";
     done >> $REVIEWERS.new
     LANG=C sort -u $REVIEWERS.new >> $REVIEWERS
     rm $REVIEWERS.new
+}
+
+function main() {
+    build_reviewer_list
 }
 
 main "$@"


### PR DESCRIPTION
Review commit by commit.

- **ladder: Revert reviewer status without being members**
- **tools/reviewers: Refactor list creation**
- **tools/reviewers: Update member list**
- **ladder: Sort member list correctly**

This should ensure that the GitHub workflows that lint for correctness will
avoid the situation where the repository declares a reviewer who is not also a
member of the organization as defined in this repository.

Related: https://github.com/cilium/community/pull/274
Related: https://github.com/cilium/community/pull/277
Related: https://github.com/cilium/community/pull/278
