### PR TITLE
teams: add bimmlerd to release-managers

### DIFF
--- a/ladder/teams/release-managers.yaml
+++ b/ladder/teams/release-managers.yaml
@@ -1,6 +1,7 @@
 members:
 - aanm
 - asauber
+- bimmlerd
 - gentoo-root
 - joestringer
 - jrajahalme


### PR DESCRIPTION
I've previously done patch releases and plan on doing so in the future. Being part of the release-manager team will allow me to help out other release managers with review.

https://github.com/cilium/release/issues?q=is%3Aissue%20state%3Aclosed%20author%3Abimmlerd

Note: I'm not a committer (yet?), if that's required that'll have to come first.