### PR TITLE
ladder: add msune as member

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -81,6 +81,7 @@ members:
 - mhofstetter
 - michi-covalent
 - mmat11
+- msune
 - mtardy
 - mvisonneau
 - nathanjsweet


### PR DESCRIPTION
Add Marc Suñé (me) to the members.yaml file, just so that I can shortcut one reviewer RTT during PRs (launch /test) :).