### PR TITLE
Add jrife to sig-datapath

### DIFF
--- a/ladder/reviewers.yaml
+++ b/ladder/reviewers.yaml
@@ -32,6 +32,7 @@ reviewers:
 - joestringer
 - jrajahalme
 - jrfastab
+- jrife
 - jschwinger233
 - julianwiedmann
 - kaworu

--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -19,5 +19,6 @@ members:
 - rastislavs
 - tommyp1ckles
 - ysksuzuki
+- jrife
 mentors:
 - joestringer


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:
(Updated links to point to jrife)

- [x] Link to issues you have opened. Check this [here](https://github.com/search?q=org%3Acilium+author%3Ajrife&type=issues)
- [x] Link to pull requests you have reviewed. Check this [here](https://github.com/search?q=org%3Acilium+reviewed-by%3Ajrife&type=pullrequests)
- [x] Link to pull requests you have authored. Check this [here](https://github.com/search?q=org%3Acilium+author%3Ajrife&type=pullrequests)
- [ ] Links to discussions or issues you actively participated in
- [x] Other relevant community involvement
  - Attendee at last year's NA Cilium Dev Summit.

## Additional Notes
* @pchaigno suggested adding myself as a reviewer + sig-datapath member
* Occasional kernel contributor: [bpf](https://lore.kernel.org/bpf/?q=jordan+rife), [netdev](https://lore.kernel.org/netdev/?q=jordan+rife)
  * [1](https://lore.kernel.org/netdev/20230821162616.640423-1-jrife@google.com/) [2](https://lore.kernel.org/netdev/20230921234642.1111903-1-jrife@google.com/T/#u) to make socketLB work with NFS+kernel sockets: https://github.com/cilium/cilium/issues/21541
  * [1](https://lore.kernel.org/bpf/20250502161528.264630-1-jordan@jrife.io/),[2](https://lore.kernel.org/bpf/20250714180919.127192-1-jordan@jrife.io/) to make socket iterators better. Related: https://github.com/cilium/cilium/pull/38693
  * [1](https://lore.kernel.org/netdev/20250517192955.594735-1-jordan@jrife.io/T/#u) to make WireGuard better. Related: https://github.com/cilium/cilium/pull/34612
* Assisted in backport of Netkit fixes into Ubuntu 6.8 kernels.
* Member/contributor to [bpftrace](https://github.com/orgs/bpftrace/people)
