### PR TITLE
fix(readme): update slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out the [contributor ladder](CONTRIBUTOR-LADDER.md) for different ways to 
 Connect with the community through:
 
 * Follow us on [Twitter](https://twitter.com/ciliumproject), [LinkedIn](https://www.linkedin.com/company/cilium/), and our [blog](https://cilium.io/blog/)
-* Chat with us on [Slack](https://cilium.slack.com/join/shared_invite/zt-3bkub0a2q-8uggdJGa95QJOQogxkDnww#/shared-invite/email)
+* Chat with us on [Slack](https://slack.cilium.io/)
 * Subscribe to [the newsletter](https://cilium.io/newsletter)
 * Subscribe to the [eBPF and Cilium Community on Youtube](https://www.youtube.com/channel/UCJFUxkVQTBJh3LD1wYBWvuQ)
 


### PR DESCRIPTION
Fix the link to Slack to point to slack.cilium.io