### PR TITLE
Add kaworu to hubble-maintainers team

### DIFF
--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -14,10 +14,10 @@ The Maintainers roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](
 
 ## [hubble-maintainers]: Maintainers of [cilium/hubble](https://github.com/cilium/hubble) and the Hubble subsystem in [cilium/cilium](https://github.com/cilium/cilium)
 
+* [Alexandre Perrin](https://github.com/kaworu)
 * [Chance Zibolski](https://github.com/chancez)
 * [Glib Smaga](https://github.com/glibsm)
 * [Robin Hahling](https://github.com/rolinh)
-* [Sebastian Wicki](https://github.com/gandro)
 
 ## [tetragon-maintainers]: Maintainers of [cilium/tetragon](https://github.com/cilium/tetragon)
 


### PR DESCRIPTION
I propose Alexandre Perrin (@kaworu)  [^1] to be added to the hubble-maintainers team [^2] to recognize and celebrate their tremendous contributions to Hubble subsystem and Cilium observability in general.

At the same time, I (Sebastian Wicki) will retire from the maintainer role in Hubble. I will however remain active in the community as a Hubble reviewer and Cilium committer. This leaves the Hubble project with two maintainers each in the European and US timezones.

*Qualifications* [^3]:

> Demonstrates a broad knowledge of the project across multiple areas

Alex contributions to Hubble are too many to list them all, as he has been active in the project for over five years now. Some highlights include is early contributions to the Hubble Relay mTLS certificate handling [^4][^5][^6], the many many API extensions for various flow fields and filters over the years [^7][^8][^9][^10], and most recently support for encapsulated traffic in Hubble [^11].

> Must be a Cilium committer

Alex is a Cilium committer.

> Talk to the current maintainers about which part of the project you
> would like to help with.

I have talked the other current Hubble maintainers (@rolinh @glibsm @chancez) regarding my proposal, and I believe they are more than happy for Alex to take over my responsibilities in the Hubble project.

[^1]: https://github.com/kaworu
[^2]: https://github.com/orgs/cilium/teams/hubble-maintainers
[^3]: https://github.com/cilium/community/blob/main/CONTRIBUTOR-ROLES.md#maintainers
[^4]: https://github.com/cilium/cilium/pull/13249
[^5]: https://github.com/cilium/cilium/pull/15443
[^6]: https://github.com/cilium/cilium/pull/22995
[^7]: https://github.com/cilium/cilium/pull/21296
[^8]: https://github.com/cilium/cilium/pull/24120
[^9]: https://github.com/cilium/cilium/pull/32851
[^10]: https://github.com/cilium/cilium/pull/33325
[^11]: https://github.com/cilium/cilium/pull/37634