### PR TITLE
ladder: add bigdelle to members

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -1,6 +1,7 @@
 members:
 - AritraDey-Dev
 - Artyop
+- Bigdelle
 - DamianSawicki
 - ExceptionalHandler
 - HadrienPatte


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:
#### Merged PRs:
* [CFP: Packet Tracing cilium](https://github.com/cilium/design-cfps/pull/44)
* [cilium: add IP option packet tracing feature](https://github.com/cilium/cilium/pull/41306)
* [Enable verbose debug messages for tagged packets](https://github.com/cilium/cilium/pull/41839)
#### Open PRs:
* [Adding bpf.monitorTraceIPOption flag to helm chart](https://github.com/cilium/cilium/pull/41636)
* [fix(bpf) Initialize cilium_percpu_trace_id map via Hive Start hook](https://github.com/cilium/cilium/pull/41886)
* [fix(cilium-dbg): include pod backends in lrp list](https://github.com/cilium/cilium/pull/42110)
#### Issues worked on:
* [CiliumLocalRedirectPolicy doesnt work with skipRedirectFromBackend](https://github.com/cilium/cilium/issues/40450#issuecomment-3387878962)

## Additional Notes
I am actively working on additional features (specifically for the IP tracing feature that was merged) that would be great to have testing privileges. Becoming an org member would be a really helpful way to speed up development and lower dead time by being able to get PRs up to the best state of review.