### PR TITLE
teams: add ztunnel team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,3 +47,4 @@
 /ladder/teams/tetragon.yaml @cilium/tetragon
 /ladder/teams/vendor.yaml @cilium/vendor
 /ladder/teams/wireguard.yaml @cilium/wireguard
+/ladder/teams/ztunnel.yaml @cilium/ztunnel

--- a/ladder/teams/ztunnel.yaml
+++ b/ladder/teams/ztunnel.yaml
@@ -1,0 +1,4 @@
+members:
+- hemanthmalla
+- ldelossa
+- rgo3


### PR DESCRIPTION
Create a dedicated ztunnel team to own ztunnel-specific code paths. While sig-encryption exists, only two members actively participated in the ztunnel integration development. A focused team ensures better ownership and maintenance of this subsystem.

## Additional Notes
The code owned by this new team will only be added/proposed shortly, but IIUC adding the team first so that I can add it as the respective codeowner in the first relevant PR is the correct sequence of events.
