### PR TITLE
Remove Sarah from docs reviewers

### DIFF
--- a/ladder/reviewers.yaml
+++ b/ladder/reviewers.yaml
@@ -77,4 +77,3 @@ reviewers:
 - yannikmesserli
 - youngnick
 - ysksuzuki
-- zacharysarah

--- a/ladder/teams/docs-structure.yaml
+++ b/ladder/teams/docs-structure.yaml
@@ -2,4 +2,3 @@ members:
 - hemanthmalla
 - joestringer
 - qmonnet
-- zacharysarah


### PR DESCRIPTION
@zacharysarah We had chatted a while ago about adding you back into the
rotation for docs reviews, but as I understand the situation has changed
since we last chatted. I attempted to reach out to you over Slack to
confirm if you were still interested to help with reviews, but the messages
do not appear to have connected. Proposing this to ensure that the docs
reviewer team matches the set of folks who are actively reviewing this area
of contributions to the Cilium project.

If you still want to be part of the team, let me know and I'll happily close
this PR, then you'll start to receive review requests soon after.

cc @cilium/docs-structure
