### PR TITLE
Remove Sean from helm team

### DIFF
--- a/ladder/reviewers.yaml
+++ b/ladder/reviewers.yaml
@@ -58,7 +58,6 @@ reviewers:
 - rgo3
 - rolinh
 - sayboras
-- seanmwinn
 - sharlns
 - smagnani96
 - squeed

--- a/ladder/teams/helm.yaml
+++ b/ladder/teams/helm.yaml
@@ -4,5 +4,4 @@ members:
 - gandro
 - nbusseneau
 - nebril
-- seanmwinn
 - squeed


### PR DESCRIPTION
@seanmwinn did an awesome job reworking our Helm charts a few years ago, but
recently he's been focused in other areas. As discussed out-of-band, he doesn't have
as much time to review Helm changes these days. Remove him from the reviewer group.

cc @cilium/helm
