### PR TITLE
Make brb mentor in sig-{datapath,encryption,lb} and wireguard

### DIFF
--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -21,4 +21,5 @@ members:
 - ysksuzuki
 - jrife
 mentors:
+- brb
 - joestringer

--- a/ladder/teams/sig-encryption.yaml
+++ b/ladder/teams/sig-encryption.yaml
@@ -7,3 +7,5 @@ members:
 - pchaigno
 - rgo3
 - smagnani96
+mentors:
+- brb

--- a/ladder/teams/sig-lb.yaml
+++ b/ladder/teams/sig-lb.yaml
@@ -8,3 +8,5 @@ members:
 - jschwinger233
 - julianwiedmann
 - ysksuzuki
+mentors:
+- brb

--- a/ladder/teams/wireguard.yaml
+++ b/ladder/teams/wireguard.yaml
@@ -4,3 +4,5 @@ members:
 - jschwinger233
 - rgo3
 - smagnani96
+mentors:
+- brb


### PR DESCRIPTION
The mentor role is described in
https://github.com/cilium/community/blob/cb8ac30288534c961c737da64d6c29cf1b2da7f6/ladder/teams/README.md?plain=1#L37-L46.