### PR TITLE
tools: Fix sorting for generate-codeowners.sh

### DIFF
--- a/tools/generate-codeowners.sh
+++ b/tools/generate-codeowners.sh
@@ -4,6 +4,8 @@
 
 set -eu
 
+LANG=C
+
 function main() {
     echo "* @cilium/committers" > CODEOWNERS
     for f in ladder/teams/*.yaml; do


### PR DESCRIPTION
When running this test locally, I got different ordered items in the
resulting CODEOWNERS file. Applying this LANG setting fixed it so that
it matched the sort order observed in CI on GitHub.
