### PR TITLE
Add GKE team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 /ladder/teams/envoy.yaml @cilium/envoy
 /ladder/teams/fqdn.yaml @cilium/fqdn
 /ladder/teams/github-sec.yaml @cilium/github-sec
+/ladder/teams/gke.yaml @cilium/gke
 /ladder/teams/helm.yaml @cilium/helm
 /ladder/teams/hubble-metrics.yaml @cilium/hubble-metrics
 /ladder/teams/hubble-ui.yaml @cilium/hubble-ui

--- a/ladder/teams/gke.yaml
+++ b/ladder/teams/gke.yaml
@@ -1,0 +1,3 @@
+members:
+- Artyop
+- jrife


### PR DESCRIPTION
Add GKE team to keep GKE-specific workflows running.

## Additional Notes
* Relevant [discussion on slack](https://cilium.slack.com/archives/C7PE7V806/p1761289404779719?thread_ts=1761066570.354589&cid=C7PE7V806)
* Corresponding CODEOWNERS change in cilium/cilium: https://github.com/cilium/cilium/pull/42380
