### PR TITLE
tetragon: introduce TETRAGON.md with Tetragon Contributor Ladder

### DIFF
--- a/TETRAGON.md
+++ b/TETRAGON.md
@@ -1,0 +1,40 @@
+# Tetragon Governance
+
+Tetragon, [as a core sub-project within Cilium](REPOSITORIES.md), follows the [Governance](GOVERNANCE.md) and [Contributor Ladder](CONTRIBUTOR-LADDER.md).
+
+## Tetragon Contributor Ladder
+
+The following [Contributor Ladder](CONTRIBUTOR-LADDER.md) roles apply without any modification to the Tetragon project:
+
+* *Community Contributor*
+* *Organization Member*
+* *Reviewer*
+
+In addition to these roles, the Tetragon project adds the “Tetragon Committer” role that is placed between the role of *Reviewer* and *Committer*. Tetragon Committers are similar to *Committers* (as specified in the [Contributor Ladder](CONTRIBUTOR-LADDER.md)) but only within the scope of the Tetragon project. More precisely, their scope of responsibilities, qualifications, and privileges are equivalent to *Committers* but only applicable within the scope of the Tetragon project. Note that a Tetragon Committer is not granted the status of Cilium “maintainer” in CNCF parlance.
+
+### Tetragon Committer
+
+Tetragon Committers have write, merge, and voting privileges, and are collectively responsible for steering the Tetragon project in a positive direction. As such it represents a significant level of trust in an individual's commitment to working with other Tetragon Committers and the community at large for the benefit of the Tetragon project.
+
+Tetragon Committers have all the rights and responsibilities of a Reviewer, plus:
+
+* Responsibilities:
+  * Mentoring new Tetragon Committers
+  * Discussing strategy and policy for the project
+  * Voting on Tetragon project matters when required
+  * Additional responsibilities specific to any project roles they may have
+  * Approve contributors to assume roles
+* Qualifications:
+  * Laid out in granting commit access
+  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+  * Is able to exercise judgment for the good of the Tetragon project, independent of their employer, friends, or team
+  * Mentors other contributors
+* Privileges:
+  * Can merge code into the Tetragon repository
+  * Represent the project in public as a Tetragon Committer
+  * Can nominate new Tetragon Committers
+  * Is listed as a Tetragon Committer in Tetragon’s MAINTAINERS.md
+
+Tetragon Committers who are contributing and maintaining project code are automatically part of the Code Team defined in [CONTRIBUTOR-ROLES.md](CONTRIBUTOR-ROLES.md).
+
+Granting and Revoking Tetragon Committer access falls under the same rules as the “Cilium committer grant/revocation policy” specified in [Governance](GOVERNANCE.md). Discussions happen in `#tetragon-committers` instead of `#committers.`


### PR DESCRIPTION
Introduce a document that specifies the new role of Tetragon Committer that is valid within the Tetragon project.
