### PR TITLE
Add certgen team and certgen maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 /ladder/teams/aws.yaml @cilium/aws
 /ladder/teams/azure.yaml @cilium/azure
 /ladder/teams/build.yaml @cilium/build
+/ladder/teams/certgen.yaml @cilium/certgen
 /ladder/teams/ci-structure.yaml @cilium/ci-structure
 /ladder/teams/cilium-io.yaml @cilium/cilium-io
 /ladder/teams/cli.yaml @cilium/cli

--- a/ladder/teams/certgen.yaml
+++ b/ladder/teams/certgen.yaml
@@ -1,0 +1,7 @@
+members:
+- chancez
+- gandro
+- giorio94
+- glrf
+- kaworu
+- rolinh

--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -46,6 +46,11 @@ The Maintainers roles and responsibilities are listed in [CONTRIBUTOR-ROLES.md](
 
 * [Martynas Pumputis](https://github.com/brb)
 
+## [certgen-maintainers]: Maintainers of [cilium/certgen](https://github.com/cilium/certgen)
+
+* [Marco Iorio](https://github.com/giorio94)
+
+[certgen-maintainers]: https://github.com/orgs/cilium/teams/certgen-maintainers
 [cilium-cli-maintainers]: https://github.com/orgs/cilium/teams/cilium-cli-maintainers
 [cilium-maintainers]: https://github.com/orgs/cilium/teams/cilium-maintainers
 [cilium.io-maintainers]: https://github.com/orgs/cilium/teams/cilium-io-maintainers


### PR DESCRIPTION
Certgen is a project that was created in 2020, when the Hubble team added support for automatic TLS certificates generation for Hubble and Hubble Relay. The earlier versions were strictly tied to Hubble and Relay. However, v0.2 marks a major departure in the project which became generic and reusable by projects other than Hubble and Cilium. Since then, it is also used to generate TLS certificates automatically for Cluster Mesh and has been adopted by other projects.

For the last years, I have been the de-facto maintainer of the project, ensuring to review contributions, taking care of updates and tagging releases. Others contributors such as Alex and Sebastian have also helped with maintenance in the past. However, I think it is time to formalize the maintenance of the project.

Although Alex and myself have been the main maintainers in the recent years, the major surgery that lead to v0.2 was conducted by Marco. Given that Alex and myself are already Hubble co-maintainers, I reached out to Marco to ask him whether he would agree to become the certgen maintainers, to which he replied yes.

Therefore, this commit mainly does two things:

- Add a `certgen` team
- Nominate Marco Ioro as the certgen maintainer

Note that I have added members to the certgen team based on past contributions, reviews or interest that was manifested. I will make sure to ask everyone concerned for a review if they'd rather opt out.
