### PR TITLE
Remove jschwinger233 from sig-lb

### DIFF
--- a/ladder/teams/sig-lb.yaml
+++ b/ladder/teams/sig-lb.yaml
@@ -5,7 +5,6 @@ members:
 - brb
 - dylandreimerink
 - joamaki
-- jschwinger233
 - julianwiedmann
 - ysksuzuki
 mentors:


### PR DESCRIPTION
Hey @jschwinger233, I reached out on Slack but I was unable to connect with
you. I understand you are still involved in some Cilium development
activities but I couldn't quite tell which areas you plan to focus on. You have
historically been excluded from review rotation for @cilium/sig-lb reviews,
but we will be removing all such exclusions from the backend system soon.
If no action is taken, then you would be expected to review PRs for that team.
You are quite welcome to remain part of the team, just respond to let me know
and I will close this PR.

This PR is prepared to ensure we do not impose additional expectations on you
that you are unprepared to uphold as part of your participation in the project.
If you no longer wish to review and contribute to this area, this PR will
remove you from that team. You would be welcome to rejoin in future if your
focus in the Cilium project changes.

If you do not respond in the next week or so, I will assume you are no longer
involved in this area and I will merge the PR to remove you from this team.
