### PR TITLE
Remove michi-covalent from the build team

### DIFF
--- a/ladder/teams/build.yaml
+++ b/ladder/teams/build.yaml
@@ -5,7 +5,6 @@ members:
 - gentoo-root
 - hemanthmalla
 - joestringer
-- michi-covalent
 - nebril
 - thorn3r
 - tklauser


### PR DESCRIPTION
I haven't been involved with the build team for a while.