### PR TITLE
tools: Allow codeowners to be overridden

### DIFF
--- a/tools/generate-codeowners.sh
+++ b/tools/generate-codeowners.sh
@@ -7,10 +7,14 @@ set -eu
 LANG=C
 
 function main() {
-    echo "* @cilium/committers" > CODEOWNERS
+    echo "* @cilium/committers" > CODEOWNERS.new
     for f in ladder/teams/*.yaml; do
-        echo "/$f @cilium/$(basename $f | sed 's/.yaml//')";
-    done >> CODEOWNERS
+        team="$(basename --suffix '.yaml' "$f")"
+        if ! grep "teams/$team.yaml" CODEOWNERS; then
+        echo "/$f @cilium/$team";
+        fi
+    done >> CODEOWNERS.new
+    mv CODEOWNERS.new CODEOWNERS
 }
 
 main "$@"


### PR DESCRIPTION
The linter for generating codeowners so far was mainly focused on
ensuring that each team will request review from other members of the
team, so that teams can self-organize. The merging of the team
membership changes are done through approval and merge from the
committers group on cilium/community repository.

However, the previous iteration of this scripting did not allow
codeowners paths to be overridden in specific cases, such as subprojects
which have different approval patterns.

Update the linter to ensure that each team has an owner, but do not
override existing owners in the tree.

Related: https://github.com/cilium/community/pull/338#issuecomment-3510734549