### PR TITLE
Add smagnani96 to sig-datapath

### DIFF
--- a/ladder/teams/sig-datapath.yaml
+++ b/ladder/teams/sig-datapath.yaml
@@ -15,6 +15,7 @@ members:
 - julianwiedmann
 - ldelossa
 - pchaigno
+- smagnani96
 - tommyp1ckles
 - ysksuzuki
 mentors:


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:
- [x] Link to issues you have opened. Check this [here](https://github.com/search?q=org%3Acilium+author%3A%40me+&type=issues)
- [x] Link to pull requests you have reviewed. Check this [here](https://github.com/search?q=org%3Acilium+reviewed-by%3A%40me&type=pullrequests)
- [x] Link to pull requests you have authored. Check this [here](https://github.com/search?q=org%3Acilium+author%3A%40me&type=pullrequests)
- [ ] Links to discussions or issues you actively participated in
- [ ] Other relevant community involvement

## Additional Notes
My main contributions so far have involved datapath code.
My first contribution were mainly IPSec and Wireguard related. They're too right now, but I'm trying enlarge the scope.
Recently I contributed to many fixes, refactor, and features to our datapath tracing, enabling Hubble to decode Overlay packets. I've also reviewed many datapath-related PRs, and provided a script (verifier_diff.py) for checking our verifier complexity increase.

cc @joestringer 
