### PR TITLE
tetragon-committers: add andrewstrohman

### DIFF
--- a/ladder/teams/tetragon-committers.yaml
+++ b/ladder/teams/tetragon-committers.yaml
@@ -1,6 +1,7 @@
 members:
 - ExceptionalHandler
 - FedeDP
+- andrewstrohman
 - jrfastab
 - kevsecurity
 - kkourt


### PR DESCRIPTION
Add Andy Strohman to tetragon-committers.

# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
   
## My Relevant Contributions to the Cilium Ecosystem:
Opened Issues: https://github.com/search?q=org%3Acilium+author%3A%40andrewstrohman+&type=issues
Reviewed PRs: https://github.com/search?q=org%3Acilium+reviewed-by%3A%40andrewstrohman&type=pullrequests
Authored PRs: https://github.com/search?q=org%3Acilium+author%3A%40andrewstrohman&type=pullrequests

I've attended most monthly tetragon community meetings since October 2025.


## Additional Notes
Since [becoming a tetragon reviewer](https://github.com/cilium/community/commit/8438eeb0c6dd04935d46d39d494a78bfb9761925), I've carefully and promptly reviewed all PRs assigned to me. By becoming a tetragon-committer, I hope to take my contribution to the next level.