### PR TITLE
Add policy for generative artificial intelligence

### DIFF
--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -1,0 +1,115 @@
+# Cilium Generative AI Policy
+
+To maintain the high quality and trustworthiness of contributions to the Cilium
+community, we provide the following guidance on the use of "Generative
+Artificial Intelligence", including large language models (LLMs), GitHub
+Copilot, ChatGPT, Codex, Claude code, or similar tools ("Generative AI"). The
+guidance in this document is intended for all contributors to the community. As
+a Linux Foundation project, Cilium is also subject to the Linux Foundation
+[Guidance Regarding Use of Generative AI Tools]. The guidance in this document
+is intended to support you as a contributor in addition to the Linux Foundation
+guidance.
+
+## Guiding Principle
+
+Cilium is a community-driven organization that values expertise, clear
+communication, and personal responsibility. The community prides itself on a
+commitment to high quality and trust amongst its members. To maintain this in
+the AI era, we follow a key principle:
+
+**What you do with Generative AI reflects on you**.
+
+Successful ongoing contribution to this community is contingent on building
+trust with the members of the organization through ongoing collaboration.
+Whether or not Generative AI tools were involved, you are fully accountable for
+the correctness, security, and clarity of your contributions. Human review is
+required for all code, including code generated or assisted by Generative AI
+tools. If you contribute regularly, other contributors will become familiar
+with your work, so we request that you mindfully consider the impact that your
+use of Generative AI may have on other community members.
+
+## Acceptable Use
+
+We recognize that Generative AI can be a helpful _tool_, for example you may
+use it to:
+
+- Explain parts of the codebase you don’t understand;
+- Auto-complete routines or boilerplate code (such as error handling, test
+  scaffolding, function signatures);
+- Reformat or refactor existing content;
+- Brainstorm ideas for implementation cases, but write the actual code yourself;
+- Draft test cases which you subsequently review, revise and simplify before
+  submission; or
+- Analyze your own content submissions.
+
+These uses are acceptable provided you:
+
+- Are involved in the entire process for creating the contributions;
+- Personally review and edit generated content before you submit it to the
+  organization;
+- Fully understand and review the content prior to submission;
+- Take personal responsibility for the content, in the same way as if you
+  authored the content without using Generative AI;
+- Ensure the output adheres to project guidelines and licensing requirements; and
+- Report the use of Generative AI tools for non-trivial preparation of
+  submissions (that is, at level 2 or higher on the [AI Influence Level]).
+
+## Unacceptable Use
+
+It is not acceptable to use Generative AI tools to:
+
+- Communicate in any Cilium community space with content that is substantially
+  written using Generative AI tools. For example, it is not acceptable to send
+  such text on Slack or GitHub, whether initiating or responding to discussion
+  with other community members.
+- Submit code, documentation, or discussion content that you have not reviewed
+  in careful detail, including testing the content where applicable.
+- Rely solely or primarily on Generative AI output for technical problem
+  solving, architectural decision making.
+- Submit work produced via Generative AI tooling that copies from external
+  sources without correct attribution or licensing.
+- Submit contributions where you cannot explain, contextualize, or justify the
+  submission as part of review.
+
+## Generative AI for Translation
+
+If you are interacting in a Cilium community space which primarily uses a
+language which you are not fluent in, community members will generally
+appreciate your attempts to express your ideas in that language without the use
+of Generative AI tools. However, we recognize that contributors from around the
+world may want to participate in discussion in the Cilium community, and the
+community can benefit from those discussions even if Generative AI is used to
+facilitate those discussions. When communicating in a language you are not
+confident in, consider drafting your intended response and attempt to convey
+your ideas in the target language first. If you believe the ideas are not
+conveyed clearly, consider using translation tools (either non-generative or
+generative). Be aware that if you rely significantly on Generative AI for
+translation, this itself may inhibit communication due to limitations in
+Generative AI tooling.
+
+## Transparency & Attribution
+
+We generally expect contributors to declare when Generative AI was used to
+prepare a submission. For non-trivial text or code submissions (such as new
+features, documentation pages, complex design proposals), you should describe
+how Generative AI was used and explain the human review process applied. For
+trivial use of Generative AI (such as spelling check or simple autocomplete)
+you are not expected to declare use. Suspected use of Generative AI tooling
+without transparency may lead to submissions being closed or rejected without
+discussion.
+
+## DCO and Licensing
+
+The [Developer Certificate of Origin] (DCO) is required for contributions to
+the Cilium organization. AI tools often lack transparency into their training
+data and may produce output with pre-existing copyright. If you submit
+AI-assisted contributions, you are personally certifying that you have the
+right to contribute the content under the project's license. The Linux
+Foundation [Guidance Regarding Use of Generative AI Tools] provides a more
+detailed description of your obligations as a contributor. If you’re unsure
+about the licensing of code you created using Generative AI tools,
+**don’t submit it**.
+
+[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
+[Developer Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin
+[Guidance Regarding Use of Generative AI Tools]: https://www.linuxfoundation.org/legal/generative-ai


### PR DESCRIPTION
The Cilium community builds and distributes a range of software that is
critical for operating many pieces of modern Internet infrastructure. In
order to uphold the trust our users place in our software, the Cilium
community maintains a high quality bar for contributions. We cultivate
this bar by investing significant time and effort into contributors who
show a sustained interest in contributing to systems development. Over
time, by spending time learning, contributing, and mentoring others, we
build trust in newer contributors, delegate trust to them, and
ultimately increase the community's capacity to work on our shared
[vision].

We've identified and recognized several committers and maintainers over
time through their activity within this community. These valuable
maintainers of the project started as individual contributors and grew
their involvement over time, gradually building trust within the
community. The pattern of these contributors is a common one: They start
small, they learn the project's guidelines and expectations, and they
give more to the community than what they take. For core team members,
it's a pleasure to work with these individuals as we collectively build
software we can all be proud of. We are able to move faster by
delegating significant trust to the individuals we frequently work with.

Recent industry developments in software tooling have lowered the
barrier of entry for people to generate contributions to open source
communities. We see newer contributors jump directly to proposing
larger, more complex changes. The purported author of these changes
often cannot explain why they are trying to make the change. At a
cursory glance, these changes may appear sensible enough, but reviewers
must spend significant time considering the details of the
implementation and identifying potential technical debt and long term
maintenance burden. In the past, a contributor would need to be heavily
invested in the community in order to submit such a change, but these
are now created by "drive-by" contributors.

The result of this trend is that reviewers feel overburdened by the
volume of submissions. It is harder to recognize when contributors intend
to stick around in the community to help maintain the changes over time.
There are more contributors to teach and mentor, but it's less clear
whether the time spent teaching newer contributors will lead to the
community growing. Key decisions about longer term architecture and
maintenance are not naturally brought up as part of larger
contributions, because the contributors themselves have not been
involved in the community enough to recognize that tech debt. And
reviewers are demotivated by submissions which are made by untrusted
individuals who cannot demonstrate understanding of how to build quality
systems software.

The goal of this contribution is to set out clear guidance on the use of
generative AI tooling in order to build a healthy and vibrant community.
Newer contributors should benefit from this guidance by understanding
the expectations for their contributions. Those who are able to
acknowledge this guidance, learn, and contribute on an ongoing basis can
more easily build trust in the community through clear communication. At
the same time, reviewers and maintainers can use this guidance to
balance the time they spend on contributions based on the effort put in
by the contributor.

This policy has been drafted over the past several months in consultation
with a range of community members and committers. Notably, it draws
inspiration from discussions in the following sources:

- https://github.com/cilium/community/discussions/239
- https://github.com/zulip/zulip/commit/2be6c72cbbca65c039bc129f78a2bc0f8fd16770
- https://github.com/bootc-dev/infra/commit/3e0c644d172f697e20e5bb4450d407dd293ea14a

[vision]: https://github.com/cilium/community/blob/main/VISION.md

Co-authored-by: @xmulligan (PR content; This description is my own musings)