### PR TITLE
Clean up release managers team

### DIFF
--- a/ladder/teams/release-managers.yaml
+++ b/ladder/teams/release-managers.yaml
@@ -1,11 +1,3 @@
 members:
 - aanm
-- asauber
-- bimmlerd
-- gentoo-root
 - joestringer
-- jrajahalme
-- michi-covalent
-- nebril
-- qmonnet
-- thorn3r


### PR DESCRIPTION
We're reviewing the processes around putting out releases in order to
further streamline and automate them. In future we plan to rework this
group so that it consists of committers to the project. For now, reduce
the set of people with these permissions.
