### PR TITLE
sig-ipam: remove myself from ipam review team.

### DIFF
--- a/ladder/teams/sig-ipam.yaml
+++ b/ladder/teams/sig-ipam.yaml
@@ -7,4 +7,3 @@ members:
 - hemanthmalla
 - pippolo84
 - tklauser
-- tommyp1ckles


### PR DESCRIPTION
This team seems well staffed and I've been focused elsewhere and haven't been keeping up enough with IPAM to not make the reviewing ipam changes a big context switch.
