### PR TITLE
ladder: add amaanx86 as an org member

### DIFF
--- a/ladder/members.yaml
+++ b/ladder/members.yaml
@@ -18,6 +18,7 @@ members:
 - aditighag
 - ajmmm
 - alxn
+- amaanx86
 - andrewstrohman
 - antonipp
 - anubhabMajumdar


### PR DESCRIPTION
# Moving up the [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)

## My Relevant Contributions to the Cilium Ecosystem

- [x] Link to pull requests you have authored:
  - [cilium/cilium#46116](https://github.com/cilium/cilium/pull/46116) - docs: CNI chaining guide for Oracle Kubernetes Engine (OKE). Opened May 22, been waiting on review for 3 weeks. Tested on a live cluster, OKE 1.36 + Cilium 1.19.4.
- [x] Links to issues you have opened:
  - [cilium/cilium#46107](https://github.com/cilium/cilium/issues/46107) - raised the OKE/OCI CNI chaining gap before opening the doc PR
- [x] Links to discussions or issues you actively participated in:
  - [#development slack thread](https://cilium.slack.com/archives/C2B917YHE/p1780319808962759) - followed up after no review for a week, tagged relevant people. The reason behind the follow-up is explained in [this PR comment](https://github.com/cilium/cilium/pull/46116#issuecomment-4536698717)

## Additional Notes

Reading [design-cfps#78](https://github.com/cilium/design-cfps/pull/78) on the native OCI integration direction is what got me thinking about longer term involvement. I want to see that work happen and I have the OCI production context to help push it forward, not just the docs side.

My day job is cloud infra - working across AWS and OCI for enterprise clients. Outside Cilium I have contributed upstream to projects I actually use at work: Oracle OCI Native Ingress Controller (health probes and resource limits fix, [PR #139](https://github.com/oracle/oci-native-ingress-controller/pull/139)), HashiCorp Terraform AWS Provider (CloudWatch Logs S3 Tables resources, [PR #48190](https://github.com/hashicorp/terraform-provider-aws/pull/48190)), GoHarbor (ECR China region domain fix, [PR #23326](https://github.com/goharbor/harbor/pull/23326)), and GitLab (Vue.js PDF download for markdown blob view, [MR !238594](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/238594)).

The OCI doc PR is what got me looking more seriously at Cilium contribution. It kept stalling because there is nobody with OCI context in the reviewer pool. I want to be that person - help review OCI-related PRs, flag things that break on Oracle Cloud, and make the cloud provider coverage better. Org membership is the first step.

/cc @xmulligan