### PR TITLE
Add nezdolik to security team

### DIFF
--- a/ladder/teams/security.yaml
+++ b/ladder/teams/security.yaml
@@ -6,4 +6,5 @@ members:
 - joestringer
 - jrajahalme
 - mtardy
+- nezdolik
 - rolinh


### PR DESCRIPTION
Apparently this file is actually used to manage the security team
membership, which was missed in 09666ae1d28b ("security-team: Add Kateryna").
Add Kateryna to the team properly this time.

Fixes: 09666ae1d28b ("security-team: Add Kateryna")
Fixes: https://github.com/cilium/community/pull/354