### PR TITLE
Nominate Katie Meinders as SIG Community Lead

### DIFF
--- a/sig-community/README.md
+++ b/sig-community/README.md
@@ -16,6 +16,6 @@ Join our [Slack channel](https://cilium.slack.com/archives/C08MR0FQRCM) in the C
 ### Leads
 
 The Leads are responsible for driving the operations and community initiatives of SIG Community, as well as upholding the [community values](https://github.com/cilium/community/blob/main/VALUES.md).  
-* **[Bill Mulligan]** (@xmulligan)  
+* **[Katie Meinders]** (@krmeinders)  
 * **[Bowei Du]** (@bowei)
 * **[Tamilmani Manoharan]** (@tamilmani1989)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -7,8 +7,8 @@ sigs:
     chat_link: https://cilium.slack.com/archives/C08MR0FQRCM
     leadership:
       leads:
-        - github: xmulligan
-          name: Bill Mulligan
+        - github: krmeinders
+          name: Katie Meinders
         - github: bowei
           name: Bowei Du
         - github: tamilmani1989


### PR DESCRIPTION
She has organized the last dev summits and been a regular attendee to the community meetings. I would like to nominate her to take over my role.
